### PR TITLE
feat(mcp): add forget tool for memory deletion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 A project is never done, so here goes the road map. Might be implemented in this order, or maybe not.
 
 - Better Memory Capture
-- Memory deletion via MCP tool (not just UI)
+- ~~Memory deletion via MCP tool (not just UI)~~
 - Sensitive data filtering before storage (<private> tags, configurable regex patterns, for api keys ect.)
 - Encryption of data at rest
 - Retention policy (memory TTL)

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -357,6 +357,16 @@ export function getMemory(id: string): MemoryRow | undefined {
 	return db.query<MemoryRow, [string]>("SELECT * FROM memories WHERE id = ?").get(id) ?? undefined;
 }
 
+export function getMemoryForUser(id: string, userId: string): MemoryRow | undefined {
+	return (
+		db
+			.query<MemoryRow, [string, string]>(
+				"SELECT m.* FROM memories m JOIN api_keys k ON m.api_key_id = k.id WHERE m.id = ? AND k.user_id = ?",
+			)
+			.get(id, userId) ?? undefined
+	);
+}
+
 export function listMemories(opts?: {
 	gitRemote?: string;
 	scope?: string;

--- a/server/src/mcp.test.ts
+++ b/server/src/mcp.test.ts
@@ -3,7 +3,7 @@ import { getMemory } from "./db.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { setProvider } from "./embeddings.js";
 import { setQdrantClient } from "./qdrant.js";
-import { createTestApp, getToken, setupAdmin } from "./test-helpers.js";
+import { createRegularUser, createTestApp, getToken, setupAdmin } from "./test-helpers.js";
 
 const mockVector = new Array(768).fill(0.1) as number[];
 const mockEmbed = mock(() => Promise.resolve(mockVector));
@@ -302,5 +302,75 @@ describe("MCP server", () => {
 
 		expect(data.result?.isError).toBe(true);
 		expect(data.result?.content?.[0]?.text).toContain("Embedding service unavailable");
+	});
+
+	test("forget tool deletes own memory", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		// Store a memory first
+		const storeData = await mcpCallTool(app, apiKey, "remember", {
+			content: "delete me later",
+			scope: "global",
+		});
+		const storeText = storeData.result?.content?.[0]?.text;
+		const { id } = JSON.parse(storeText ?? "{}") as { id: string };
+		expect(getMemory(id)).toBeDefined();
+
+		// Delete it
+		const data = await mcpCallTool(app, apiKey, "forget", { id });
+
+		expect(data.result?.isError).toBeUndefined();
+		const text = data.result?.content?.[0]?.text;
+		const parsed = JSON.parse(text ?? "{}") as { id: string; deleted: boolean };
+		expect(parsed.deleted).toBe(true);
+		expect(getMemory(id)).toBeUndefined();
+	});
+
+	test("forget tool returns error for nonexistent memory", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		const data = await mcpCallTool(app, apiKey, "forget", { id: "does-not-exist" });
+
+		expect(data.result?.isError).toBe(true);
+		expect(data.result?.content?.[0]?.text).toBe("Memory not found.");
+	});
+
+	test("forget tool prevents deleting another user's memory", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const adminToken = await getToken(app);
+		const adminApiKey = await createApiKey(app);
+
+		// Store a memory as admin
+		const storeData = await mcpCallTool(app, adminApiKey, "remember", {
+			content: "admin's secret memory",
+			scope: "global",
+		});
+		const { id } = JSON.parse(storeData.result?.content?.[0]?.text ?? "{}") as { id: string };
+
+		// Create a regular user and get their API key
+		const user = await createRegularUser(app, adminToken);
+		const userKeyRes = await app.request("/api/keys", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${user.token}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ label: "user-key" }),
+		});
+		const userApiKey = ((await userKeyRes.json()) as { key: string }).key;
+
+		// Try to delete admin's memory as regular user
+		const data = await mcpCallTool(app, userApiKey, "forget", { id });
+
+		expect(data.result?.isError).toBe(true);
+		expect(data.result?.content?.[0]?.text).toBe("Memory not found.");
+
+		// Verify memory still exists
+		expect(getMemory(id)).toBeDefined();
 	});
 });

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -8,6 +8,8 @@ import { validateBearerKey } from "./auth.js";
 import { parseSummary } from "./compression.js";
 import {
 	countObservations,
+	deleteMemory,
+	getMemoryForUser,
 	getRecentSessionSummaries,
 	getSessionFilesModified,
 	getSessionForUser,
@@ -16,7 +18,7 @@ import {
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import { StoreMemoryError, storeMemory } from "./ingest.js";
-import { searchMemories } from "./qdrant.js";
+import { deletePoint, searchMemories } from "./qdrant.js";
 
 const log = getLogger(["yams", "mcp"]);
 
@@ -146,6 +148,41 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					],
 				};
 			}
+		},
+	);
+
+	server.registerTool(
+		"forget",
+		{
+			description:
+				"Delete a memory by ID. Use search first to find memory IDs. Cost: DB write + vector delete, no LLM.",
+			inputSchema: {
+				id: z.string().describe("The memory ID to delete (returned by search)"),
+			},
+		},
+		async (args) => {
+			const memory = getMemoryForUser(args.id, apiKey.user_id);
+			if (!memory) {
+				return {
+					isError: true,
+					content: [{ type: "text" as const, text: "Memory not found." }],
+				};
+			}
+
+			deleteMemory(args.id);
+
+			try {
+				await deletePoint(args.id);
+			} catch (err) {
+				log.warn("Qdrant delete failed for {id}: {error}", {
+					id: args.id,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+
+			return {
+				content: [{ type: "text" as const, text: JSON.stringify({ id: args.id, deleted: true }) }],
+			};
 		},
 	);
 


### PR DESCRIPTION
Search returns memory IDs but there was no way to delete them without opening the admin UI. Now there is.

## Changes

- New `forget` MCP tool — takes a memory ID, deletes from SQLite + Qdrant
- `getMemoryForUser()` in db.ts — joins memories → api_keys to verify ownership in one query, avoids the orphan key problem where a deleted API key would make its memories undeletable
- 3 new tests: happy path, nonexistent ID, cross-user deletion attempt

## Testing

- 160 tests passing
- Lint and type check clean