### PR TITLE
feat(mcp): token-budgeted search

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ A project is never done, so here goes the road map. Might be implemented in this
 - Retention policy (memory TTL)
 - More embedding examples, should be able to be whatever configured
 - Doc's site using fumadocs
-- Token-budgeted retrieval — MCP tool takes a max_tokens param. YAMS returns the most relevant memories that fit within budget. The caller doesn't have to guess how many results to ask for.
+- ~~Token-budgeted retrieval — MCP tool takes a max_tokens param. YAMS returns the most relevant memories that fit within budget. The caller doesn't have to guess how many results to ask for.~~
 - Semantic deduplication — Before storing a memory, check similarity against existing ones. If it's >90% similar, merge or skip. Every other memory tool just keeps appending. This would keep the DB clean without manual curation.
 - Memory types / structured schemas — Not everything is the same. A "decision" (we chose Postgres over MySQL because...) is different from a "pattern" (this codebase uses repository pattern) is different from a "gotcha" (this API returns 200 on errors). Typed memories enable smarter retrieval — when Claude starts a new feature surface decisions and patterns; when debugging, surface gotchas.
 - Contradiction detection — "Last week you said use JWT for auth in project X, now you're saying session cookies." Surface conflicts instead of silently storing both. This is the kind of thing that makes AI memory actually useful vs just a blob of context.

--- a/server/src/mcp.test.ts
+++ b/server/src/mcp.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { getMemory } from "./db.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { setProvider } from "./embeddings.js";
+import { estimateTokens } from "./mcp.js";
 import { setQdrantClient } from "./qdrant.js";
 import { createRegularUser, createTestApp, getToken, setupAdmin } from "./test-helpers.js";
 
@@ -372,5 +373,87 @@ describe("MCP server", () => {
 
 		// Verify memory still exists
 		expect(getMemory(id)).toBeDefined();
+	});
+
+	test("search with max_tokens returns memories within budget", async () => {
+		// Mock returns 3 results with summaries of known length
+		const multiResultSearch = mock(() =>
+			Promise.resolve([
+				{ id: "1", version: 1, score: 0.9, payload: { summary: "a".repeat(100) } },
+				{ id: "2", version: 1, score: 0.8, payload: { summary: "b".repeat(100) } },
+				{ id: "3", version: 1, score: 0.7, payload: { summary: "c".repeat(100) } },
+			]),
+		);
+		setQdrantClient({
+			getCollections: () => Promise.resolve({ collections: [{ name: "yams_memories" }] }),
+			upsert: mockUpsert,
+			search: multiResultSearch,
+		} as unknown as import("@qdrant/js-client-rest").QdrantClient);
+
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		// Budget that fits ~1 result (each result JSON is roughly 130 chars = ~33 tokens)
+		const data = await mcpCallTool(app, apiKey, "search", {
+			query: "test",
+			max_tokens: 40,
+		});
+
+		expect(data.result?.isError).toBeUndefined();
+		const memories = JSON.parse(data.result?.content?.[0]?.text ?? "[]") as unknown[];
+		expect(memories.length).toBeGreaterThanOrEqual(1);
+		expect(memories.length).toBeLessThan(3);
+	});
+
+	test("search with max_tokens always returns at least one result", async () => {
+		const bigResultSearch = mock(() =>
+			Promise.resolve([
+				{ id: "1", version: 1, score: 0.9, payload: { summary: "x".repeat(1000) } },
+			]),
+		);
+		setQdrantClient({
+			getCollections: () => Promise.resolve({ collections: [{ name: "yams_memories" }] }),
+			upsert: mockUpsert,
+			search: bigResultSearch,
+		} as unknown as import("@qdrant/js-client-rest").QdrantClient);
+
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		// Budget smaller than one result
+		const data = await mcpCallTool(app, apiKey, "search", {
+			query: "test",
+			max_tokens: 1,
+		});
+
+		const memories = JSON.parse(data.result?.content?.[0]?.text ?? "[]") as unknown[];
+		expect(memories).toHaveLength(1);
+	});
+
+	test("search without max_tokens uses limit as before", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		await mcpCallTool(app, apiKey, "search", { query: "test", limit: 5 });
+
+		expect(mockSearch).toHaveBeenCalledTimes(1);
+		const searchCall = mockSearch.mock.calls[0] as unknown[];
+		const searchParams = searchCall[1] as Record<string, unknown>;
+		expect(searchParams.limit).toBe(5);
+	});
+});
+
+describe("estimateTokens", () => {
+	test("estimates ~4 chars per token", () => {
+		expect(estimateTokens("abcd")).toBe(1);
+		expect(estimateTokens("abcdefgh")).toBe(2);
+		expect(estimateTokens("abcde")).toBe(2);
+	});
+
+	test("handles empty string", () => {
+		expect(estimateTokens("")).toBe(0);
 	});
 });

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -22,6 +22,27 @@ import { deletePoint, searchMemories } from "./qdrant.js";
 
 const log = getLogger(["yams", "mcp"]);
 
+const CHARS_PER_TOKEN = 4;
+
+export function estimateTokens(text: string): number {
+	return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function fitTokenBudget<T>(memories: T[], maxTokens: number): T[] {
+	const result: T[] = [];
+	let used = 0;
+
+	for (const memory of memories) {
+		const text = JSON.stringify(memory);
+		const cost = estimateTokens(text);
+		if (used + cost > maxTokens && result.length > 0) break;
+		result.push(memory);
+		used += cost;
+	}
+
+	return result;
+}
+
 function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 	const server = new McpServer({
 		name: "yams",
@@ -32,12 +53,19 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 		"search",
 		{
 			description:
-				"Search memories by semantic similarity. Cost: embedding call + DB read, no LLM.",
+				"Search memories by semantic similarity. When max_tokens is set, returns the most relevant memories that fit within the token budget — no need to guess a limit. Cost: embedding call + DB read, no LLM.",
 			inputSchema: {
 				query: z.string().describe("The search query"),
 				scope: z.enum(["session", "project", "global"]).optional().describe("Filter by scope"),
 				project: z.string().optional().describe("Filter by git remote / project"),
 				limit: z.number().int().min(1).max(50).optional().describe("Max results (default 10)"),
+				max_tokens: z
+					.number()
+					.int()
+					.min(1)
+					.max(100_000)
+					.optional()
+					.describe("Token budget — returns memories until budget is exhausted. Overrides limit."),
 			},
 		},
 		async (args) => {
@@ -59,16 +87,22 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			}
 
 			try {
+				// When token-budgeted, fetch generously and trim client-side
+				const fetchLimit = args.max_tokens ? 50 : (args.limit ?? 10);
 				const results = await searchMemories(
 					vector,
 					{ git_remote: args.project, scope: args.scope, user_id: apiKey.user_id },
-					args.limit ?? 10,
+					fetchLimit,
 				);
 
-				const memories = results.map((r) => ({
+				let memories = results.map((r) => ({
 					score: r.score,
 					...(r.payload ?? {}),
 				}));
+
+				if (args.max_tokens) {
+					memories = fitTokenBudget(memories, args.max_tokens);
+				}
 
 				return {
 					content: [


### PR DESCRIPTION
Callers currently have to guess how many results to ask for. Now they can pass `max_tokens` and get back the most relevant memories that fit.

## Changes

- `max_tokens` param on the `search` MCP tool — fetches up to 50 from Qdrant, trims to fit budget using ~4 chars/token estimate
- Always returns at least one result even if it exceeds the budget (better to overflow slightly than return nothing)
- `limit` still works as before when `max_tokens` isn't set
- 5 new tests: budget trimming, always-at-least-one guarantee, limit backward compat, estimateTokens unit tests

## Testing

- 165 tests passing
- Lint and type check clean