### PR TITLE
feat: semantic dedup on memory storage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ A project is never done, so here goes the road map. Might be implemented in this
 - More embedding examples, should be able to be whatever configured
 - Doc's site using fumadocs
 - ~~Token-budgeted retrieval — MCP tool takes a max_tokens param. YAMS returns the most relevant memories that fit within budget. The caller doesn't have to guess how many results to ask for.~~
-- Semantic deduplication — Before storing a memory, check similarity against existing ones. If it's >90% similar, merge or skip. Every other memory tool just keeps appending. This would keep the DB clean without manual curation.
+- ~~Semantic deduplication — Before storing a memory, check similarity against existing ones. If it's >90% similar, merge or skip. Every other memory tool just keeps appending. This would keep the DB clean without manual curation.~~
 - Memory types / structured schemas — Not everything is the same. A "decision" (we chose Postgres over MySQL because...) is different from a "pattern" (this codebase uses repository pattern) is different from a "gotcha" (this API returns 200 on errors). Typed memories enable smarter retrieval — when Claude starts a new feature surface decisions and patterns; when debugging, surface gotchas.
 - Contradiction detection — "Last week you said use JWT for auth in project X, now you're saying session cookies." Surface conflicts instead of silently storing both. This is the kind of thing that makes AI memory actually useful vs just a blob of context.
 - ~~Observation granularity~~ — ~~Individual observation fetch by ID for precise context retrieval.~~ Timeline browsing to see chronological context around a specific observation still TODO.

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -230,6 +230,7 @@ const CONFIG_KEYS = [
 	"compression_interval_minutes",
 	"session_context_count",
 	"privacy_patterns",
+	"dedup_threshold",
 ] as const;
 
 admin.get("/settings", (c) => {
@@ -326,6 +327,12 @@ admin.put("/settings", async (c) => {
 			const num = Number(value);
 			if (!Number.isInteger(num) || num < 1 || num > 20) {
 				return c.json({ error: "session_context_count must be an integer between 1 and 20." }, 400);
+			}
+		}
+		if (key === "dedup_threshold" && value !== null) {
+			const num = Number(value);
+			if (!Number.isFinite(num) || num < 0.5 || num > 1.0) {
+				return c.json({ error: "dedup_threshold must be a number between 0.5 and 1.0." }, 400);
 			}
 		}
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -408,6 +408,10 @@ export function listMemories(opts?: {
 	return db.query<MemoryRow, (string | number)[]>(sql).all(...params);
 }
 
+export function updateMemorySummary(id: string, summary: string): void {
+	db.query("UPDATE memories SET summary = ? WHERE id = ?").run(summary, id);
+}
+
 export function deleteMemory(id: string): boolean {
 	const result = db.query("DELETE FROM memories WHERE id = ?").run(id);
 	return result.changes > 0;

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -1,15 +1,25 @@
 import { Hono } from "hono";
 import { bearerKeyMiddleware } from "./auth.js";
-import { createMemory } from "./db.js";
+import { createMemory, getConfigWithEnv, getMemory, updateMemorySummary } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
-import { upsertMemory } from "./qdrant.js";
+import { searchMemories, upsertMemory } from "./qdrant.js";
 
 const VALID_SCOPES = ["session", "project", "global"] as const;
 type Scope = (typeof VALID_SCOPES)[number];
 
 function isValidScope(scope: string): scope is Scope {
 	return VALID_SCOPES.includes(scope as Scope);
+}
+
+const DEFAULT_DEDUP_THRESHOLD = 0.92;
+
+function getDedupThreshold(): number {
+	const str = getConfigWithEnv("dedup_threshold", "YAMS_DEDUP_THRESHOLD");
+	if (!str) return DEFAULT_DEDUP_THRESHOLD;
+	const num = Number(str);
+	if (!Number.isFinite(num)) return DEFAULT_DEDUP_THRESHOLD;
+	return Math.min(Math.max(num, 0.5), 1.0);
 }
 
 interface StoreMemoryParams {
@@ -20,6 +30,8 @@ interface StoreMemoryParams {
 	gitRemote?: string | null;
 	scope?: string;
 	metadata?: Record<string, unknown> | null;
+	force?: boolean;
+	replace?: string;
 }
 
 interface StoredMemory {
@@ -30,7 +42,22 @@ interface StoredMemory {
 	created_at: string;
 }
 
-export async function storeMemory(params: StoreMemoryParams): Promise<StoredMemory> {
+export interface DuplicateMemory {
+	duplicate: true;
+	existing_id: string;
+	existing_summary: string;
+	similarity: number;
+}
+
+export type StoreMemoryResult = StoredMemory | DuplicateMemory;
+
+function isDuplicate(result: StoreMemoryResult): result is DuplicateMemory {
+	return "duplicate" in result;
+}
+
+export { isDuplicate };
+
+export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemoryResult> {
 	const scope = params.scope ?? "session";
 	if (!isValidScope(scope)) {
 		throw new StoreMemoryError(
@@ -48,6 +75,59 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoredMemo
 	} catch (err) {
 		const message = err instanceof Error ? err.message : "Unknown error";
 		throw new StoreMemoryError(`Embedding provider error: ${message}`, "embedding");
+	}
+
+	// Replace mode: overwrite an existing memory
+	if (params.replace) {
+		const existing = getMemory(params.replace);
+		if (!existing) {
+			throw new StoreMemoryError("Memory to replace not found.", "validation");
+		}
+
+		updateMemorySummary(params.replace, params.summary);
+
+		try {
+			await upsertMemory(params.replace, vector, {
+				memory_id: params.replace,
+				user_id: params.userId,
+				git_remote: gitRemote,
+				scope,
+				api_key_label: params.apiKeyLabel,
+				created_at: existing.created_at,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			throw new StoreMemoryError(`Vector storage error: ${message}`, "vector");
+		}
+
+		return {
+			id: params.replace,
+			summary: params.summary,
+			scope,
+			git_remote: gitRemote,
+			created_at: existing.created_at,
+		};
+	}
+
+	// Dedup check: search for similar memories from the same user
+	if (!params.force) {
+		const threshold = getDedupThreshold();
+		try {
+			const similar = await searchMemories(vector, { user_id: params.userId }, 1);
+			const top = similar[0];
+			if (top && top.score >= threshold) {
+				const existingId = String(top.id);
+				const existingMemory = getMemory(existingId);
+				return {
+					duplicate: true,
+					existing_id: existingId,
+					existing_summary: existingMemory?.summary ?? String(top.payload?.summary ?? ""),
+					similarity: Math.round(top.score * 1000) / 1000,
+				};
+			}
+		} catch {
+			// Qdrant unavailable — skip dedup, store anyway
+		}
 	}
 
 	const id = crypto.randomUUID();
@@ -95,6 +175,8 @@ interface IngestBody {
 	git_remote?: string;
 	scope?: string;
 	metadata?: Record<string, unknown>;
+	force?: boolean;
+	replace?: string;
 }
 
 const ingest = new Hono<AppEnv>();
@@ -123,7 +205,14 @@ ingest.post("/", async (c) => {
 			gitRemote: body.git_remote,
 			scope: body.scope,
 			metadata: body.metadata,
+			force: body.force,
+			replace: body.replace,
 		});
+
+		if (isDuplicate(result)) {
+			return c.json(result, 200);
+		}
+
 		return c.json(result, 201);
 	} catch (err) {
 		if (err instanceof StoreMemoryError) {

--- a/server/src/mcp.test.ts
+++ b/server/src/mcp.test.ts
@@ -9,22 +9,10 @@ import { createRegularUser, createTestApp, getToken, setupAdmin } from "./test-h
 const mockVector = new Array(768).fill(0.1) as number[];
 const mockEmbed = mock(() => Promise.resolve(mockVector));
 const mockUpsert = mock(() => Promise.resolve({}));
-const mockSearch = mock(() =>
-	Promise.resolve([
-		{
-			id: "pt-1",
-			version: 1,
-			score: 0.95,
-			payload: {
-				memory_id: "mem-1",
-				git_remote: "github.com/org/repo",
-				scope: "session",
-				api_key_label: "test-key",
-				created_at: "2026-01-01T00:00:00.000Z",
-			},
-		},
-	]),
-);
+const mockDelete = mock(() => Promise.resolve({}));
+// Default: return empty results (dedup won't trigger).
+// Tests that need search results override this via mockSearch.mockImplementation()
+const mockSearch = mock(() => Promise.resolve([] as unknown[]));
 
 const mockProvider: EmbeddingProvider = {
 	name: "mock",
@@ -36,6 +24,7 @@ const mockQdrantClient = {
 	getCollections: () => Promise.resolve({ collections: [{ name: "yams_memories" }] }),
 	upsert: mockUpsert,
 	search: mockSearch,
+	delete: mockDelete,
 } as unknown as import("@qdrant/js-client-rest").QdrantClient;
 
 async function createApiKey(app: ReturnType<typeof createTestApp>, jwtToken?: string) {
@@ -135,7 +124,9 @@ describe("MCP server", () => {
 		setQdrantClient(mockQdrantClient);
 		mockEmbed.mockClear();
 		mockUpsert.mockClear();
-		mockSearch.mockClear();
+		mockDelete.mockClear();
+		mockSearch.mockReset();
+		mockSearch.mockImplementation(() => Promise.resolve([] as unknown[]));
 	});
 
 	afterEach(() => {
@@ -175,6 +166,23 @@ describe("MCP server", () => {
 	});
 
 	test("search tool returns results", async () => {
+		mockSearch.mockImplementation(() =>
+			Promise.resolve([
+				{
+					id: "pt-1",
+					version: 1,
+					score: 0.95,
+					payload: {
+						memory_id: "mem-1",
+						git_remote: "github.com/org/repo",
+						scope: "session",
+						api_key_label: "test-key",
+						created_at: "2026-01-01T00:00:00.000Z",
+					},
+				},
+			]),
+		);
+
 		const app = createTestApp();
 		await setupAdmin(app);
 		const apiKey = await createApiKey(app);
@@ -523,6 +531,147 @@ describe("MCP server", () => {
 		const data = await mcpCallTool(app, userApiKey, "get_observation", { id: obsId });
 
 		expect(data.result?.content?.[0]?.text).toBe("Observation not found.");
+	});
+
+	test("remember returns duplicate when similar memory exists", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		// First store succeeds (no existing memories)
+		const first = await mcpCallTool(app, apiKey, "remember", {
+			content: "Always use strict TypeScript",
+			scope: "global",
+		});
+		const firstResult = JSON.parse(first.result?.content?.[0]?.text ?? "{}") as {
+			stored: boolean;
+			id: string;
+		};
+		expect(firstResult.stored).toBe(true);
+
+		// Mock search returns a high-similarity match for the next call
+		mockSearch.mockImplementation(() =>
+			Promise.resolve([
+				{
+					id: firstResult.id,
+					version: 1,
+					score: 0.95,
+					payload: { memory_id: firstResult.id },
+				},
+			]),
+		);
+
+		// Second store with similar content triggers dedup
+		const second = await mcpCallTool(app, apiKey, "remember", {
+			content: "Always use strict TypeScript mode",
+			scope: "global",
+		});
+
+		const result = JSON.parse(second.result?.content?.[0]?.text ?? "{}") as {
+			duplicate: boolean;
+			existing_id: string;
+			similarity: number;
+		};
+		expect(result.duplicate).toBe(true);
+		expect(result.existing_id).toBe(firstResult.id);
+		expect(result.similarity).toBeGreaterThanOrEqual(0.9);
+	});
+
+	test("remember with force skips dedup check", async () => {
+		// Mock search would return a match, but force should skip it
+		mockSearch.mockImplementation(() =>
+			Promise.resolve([
+				{
+					id: "existing-1",
+					version: 1,
+					score: 0.99,
+					payload: { memory_id: "existing-1" },
+				},
+			]),
+		);
+
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		const data = await mcpCallTool(app, apiKey, "remember", {
+			content: "Store this even if duplicate",
+			scope: "global",
+			force: true,
+		});
+
+		const result = JSON.parse(data.result?.content?.[0]?.text ?? "{}") as { stored: boolean };
+		expect(result.stored).toBe(true);
+	});
+
+	test("remember with replace overwrites existing memory", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		// Store original
+		const first = await mcpCallTool(app, apiKey, "remember", {
+			content: "Original content",
+			scope: "global",
+		});
+		const { id } = JSON.parse(first.result?.content?.[0]?.text ?? "{}") as { id: string };
+		expect(getMemory(id)?.summary).toBe("Original content");
+
+		// Replace it
+		const second = await mcpCallTool(app, apiKey, "remember", {
+			content: "Updated content",
+			scope: "global",
+			replace: id,
+		});
+
+		const result = JSON.parse(second.result?.content?.[0]?.text ?? "{}") as {
+			stored: boolean;
+			id: string;
+		};
+		expect(result.stored).toBe(true);
+		expect(result.id).toBe(id);
+		expect(getMemory(id)?.summary).toBe("Updated content");
+	});
+
+	test("remember with replace fails for nonexistent ID", async () => {
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		const data = await mcpCallTool(app, apiKey, "remember", {
+			content: "Replace nothing",
+			replace: "does-not-exist",
+		});
+
+		expect(data.result?.isError).toBe(true);
+		expect(data.result?.content?.[0]?.text).toContain("not found");
+	});
+
+	test("dedup does not trigger below threshold", async () => {
+		// Mock returns a match but below the default 0.92 threshold
+		mockSearch.mockImplementation(() =>
+			Promise.resolve([
+				{
+					id: "existing-1",
+					version: 1,
+					score: 0.7,
+					payload: { memory_id: "existing-1" },
+				},
+			]),
+		);
+
+		const app = createTestApp();
+		await setupAdmin(app);
+		const apiKey = await createApiKey(app);
+
+		const data = await mcpCallTool(app, apiKey, "remember", {
+			content: "Something somewhat related but different",
+			scope: "global",
+		});
+
+		const text = data.result?.content?.[0]?.text ?? "{}";
+		const result = JSON.parse(text) as { stored: boolean };
+		expect(result.stored).toBe(true);
 	});
 });
 

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -18,7 +18,7 @@ import {
 	listObservations,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
-import { StoreMemoryError, storeMemory } from "./ingest.js";
+import { StoreMemoryError, isDuplicate, storeMemory } from "./ingest.js";
 import { deletePoint, searchMemories } from "./qdrant.js";
 
 const log = getLogger(["yams", "mcp"]);
@@ -131,7 +131,8 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 	server.registerTool(
 		"remember",
 		{
-			description: "Store a new memory. Cost: embedding call + DB write, no LLM.",
+			description:
+				"Store a new memory. Checks for duplicates — if a similar memory exists, returns it instead of storing. Use force to skip the check, or replace to overwrite an existing memory. Cost: embedding call + vector search + DB write, no LLM.",
 			inputSchema: {
 				content: z.string().describe("The content to remember"),
 				scope: z
@@ -139,6 +140,11 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					.optional()
 					.describe("Memory scope (default: session)"),
 				project: z.string().optional().describe("Git remote / project identifier"),
+				force: z.boolean().optional().describe("Skip duplicate check and store anyway"),
+				replace: z
+					.string()
+					.optional()
+					.describe("ID of an existing memory to overwrite with new content"),
 			},
 		},
 		async (args) => {
@@ -150,7 +156,20 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					userId: apiKey.user_id,
 					gitRemote: args.project,
 					scope: args.scope,
+					force: args.force,
+					replace: args.replace,
 				});
+
+				if (isDuplicate(result)) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify(result, null, 2),
+							},
+						],
+					};
+				}
 
 				return {
 					content: [


### PR DESCRIPTION
Every memory tool just keeps appending duplicates. Now YAMS checks similarity before storing and lets the caller decide.

## How it works

When `remember` is called, the embedding vector (already computed for storage) is used to search Qdrant for similar existing memories from the same user. If the top match exceeds the threshold (default 0.92), the response returns the existing memory instead of storing:

```json
{ "duplicate": true, "existing_id": "...", "existing_summary": "...", "similarity": 0.94 }
```

The caller then decides:
- **Skip** — do nothing, the memory already exists
- **Force** — `remember` with `force: true` to store anyway
- **Replace** — `remember` with `replace: "<existing_id>"` to overwrite

## Changes

- `storeMemory()` in ingest.ts — dedup check before writing, `force` and `replace` params
- `remember` MCP tool — exposes `force` and `replace` params, returns duplicate result to caller
- `updateMemorySummary()` in db.ts — for replace mode
- `dedup_threshold` config key (0.5–1.0, default 0.92) in admin settings
- HTTP ingest endpoint also supports `force` and `replace` in request body
- 5 new tests: duplicate detection, force bypass, replace overwrite, replace nonexistent, below-threshold passthrough

## Cost

Zero extra embedding calls. One Qdrant search (limit 1) per ingest — very fast.

## Testing

- 165 tests passing
- Lint and type check clean