### PR TITLE
fix(cli): harden lib modules from test audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "dependencies": {
         "@clack/prompts": "^0.10",
         "smol-toml": "^1.6.0",
+        "zod": "^3.24",
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -1326,6 +1327,8 @@
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@huskai/cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,8 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.10",
-		"smol-toml": "^1.6.0"
+		"smol-toml": "^1.6.0",
+		"zod": "^3.24"
 	},
 	"devDependencies": {
 		"@types/node": "^22",

--- a/cli/src/lib/credentials.test.ts
+++ b/cli/src/lib/credentials.test.ts
@@ -6,7 +6,7 @@ import {
 	mock,
 	test,
 } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -30,29 +30,26 @@ mock.module("./ui.js", () => ({
 	withSpinner: async (_msg: string, fn: () => Promise<unknown>) => fn(),
 }));
 
-// Mock paths so tests don't touch real ~/.husk/
-let tempDir: string;
+// Redirect paths to temp dir so tests don't touch real ~/.husk/
+const tempDir = mkdtempSync(join(tmpdir(), "husk-cred-test-"));
 
-mock.module("./paths.js", () => {
-	tempDir = mkdtempSync(join(tmpdir(), "husk-cred-paths-"));
-	return {
-		paths: {
-			home: tempDir,
-			server: join(tempDir, "server"),
-			data: join(tempDir, "data"),
-			credentials: join(tempDir, "credentials.json"),
-			config: join(tempDir, "husk.toml"),
-			log: join(tempDir, "husk.log"),
-			pid: join(tempDir, "husk.pid"),
-			version: join(tempDir, "version.json"),
-			modelsPath: join(tempDir, "data", "models"),
-			dbPath: join(tempDir, "data", "husk.db"),
-			vectorsPath: join(tempDir, "data", "husk-vectors.db"),
-			launchdPlist: join(tempDir, "io.husk.server.plist"),
-			systemdUnit: join(tempDir, "husk.service"),
-		},
-	};
-});
+mock.module("./paths.js", () => ({
+	paths: {
+		home: tempDir,
+		server: join(tempDir, "server"),
+		data: join(tempDir, "data"),
+		config: join(tempDir, "husk.toml"),
+		credentials: join(tempDir, "credentials.json"),
+		log: join(tempDir, "husk.log"),
+		pid: join(tempDir, "husk.pid"),
+		version: join(tempDir, "version.json"),
+		modelsPath: join(tempDir, "data", "models"),
+		dbPath: join(tempDir, "data", "husk.db"),
+		vectorsPath: join(tempDir, "data", "husk-vectors.db"),
+		launchdPlist: join(tempDir, "io.husk.server.plist"),
+		systemdUnit: join(tempDir, "husk.service"),
+	},
+}));
 
 const { isFirstRun, setupAdmin, readCredentials } = await import(
 	"./credentials.js"
@@ -123,10 +120,16 @@ describe("readCredentials", () => {
 		expect(readCredentials()).toBeNull();
 	});
 
+	test("returns null for JSON that fails schema validation", () => {
+		writeFileSync(
+			join(tempDir, "credentials.json"),
+			JSON.stringify({ url: 123, apiKey: null }),
+		);
+		expect(readCredentials()).toBeNull();
+	});
+
 	afterEach(() => {
-		// Clean up credentials file between tests
 		try {
-			const { unlinkSync } = require("node:fs");
 			unlinkSync(join(tempDir, "credentials.json"));
 		} catch {}
 	});
@@ -142,7 +145,6 @@ describe("setupAdmin", () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
 		try {
-			const { unlinkSync } = require("node:fs");
 			unlinkSync(join(tempDir, "credentials.json"));
 		} catch {}
 	});

--- a/cli/src/lib/credentials.ts
+++ b/cli/src/lib/credentials.ts
@@ -2,18 +2,22 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import * as p from "@clack/prompts";
+import { z } from "zod";
 import { paths } from "./paths.js";
 import { withSpinner } from "./ui.js";
 
-export interface Credentials {
-	url: string;
-	apiKey: string;
-	username: string;
-}
+const CredentialsSchema = z.object({
+	url: z.string(),
+	apiKey: z.string(),
+	username: z.string(),
+});
+
+export type Credentials = z.infer<typeof CredentialsSchema>;
 
 export function readCredentials(): Credentials | null {
 	try {
-		return JSON.parse(readFileSync(paths.credentials, "utf-8"));
+		const data = JSON.parse(readFileSync(paths.credentials, "utf-8"));
+		return CredentialsSchema.parse(data);
 	} catch {
 		return null;
 	}
@@ -86,7 +90,9 @@ export async function setupAdmin(
 			throw new Error("Failed to create API key");
 		}
 
-		const keyData = (await keyRes.json()) as { key: string };
+		const keyData = z
+			.object({ key: z.string() })
+			.parse(await keyRes.json());
 
 		const creds: Credentials = {
 			url: baseUrl,

--- a/cli/src/lib/paths.test.ts
+++ b/cli/src/lib/paths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { writeFileSync, unlinkSync } from "node:fs";
 import { paths } from "./paths.js";
 
 const home = homedir();
@@ -40,6 +41,36 @@ describe("paths", () => {
 	test("no double slashes in any path", () => {
 		for (const [key, value] of Object.entries(paths)) {
 			expect(value).not.toContain("//");
+		}
+	});
+});
+
+describe("HUSK_HOME override", () => {
+	test("HUSK_HOME env var overrides all paths", () => {
+		const customHome = "/tmp/custom-husk-home";
+		const scriptPath = join(import.meta.dir, "_husk_home_test.ts");
+		writeFileSync(
+			scriptPath,
+			'import { paths } from "./paths.js";\nprocess.stdout.write(JSON.stringify(paths));',
+		);
+		try {
+			const result = Bun.spawnSync({
+				cmd: ["bun", scriptPath],
+				env: { ...process.env, HUSK_HOME: customHome },
+			});
+			const overridden = JSON.parse(result.stdout.toString());
+			expect(overridden.home).toBe(customHome);
+			expect(overridden.server).toBe(join(customHome, "server"));
+			expect(overridden.data).toBe(join(customHome, "data"));
+			expect(overridden.credentials).toBe(join(customHome, "credentials.json"));
+			expect(overridden.config).toBe(join(customHome, "husk.toml"));
+			expect(overridden.log).toBe(join(customHome, "husk.log"));
+			expect(overridden.pid).toBe(join(customHome, "husk.pid"));
+			expect(overridden.version).toBe(join(customHome, "version.json"));
+		} finally {
+			try {
+				unlinkSync(scriptPath);
+			} catch {}
 		}
 	});
 });

--- a/cli/src/lib/paths.ts
+++ b/cli/src/lib/paths.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const HUSK_HOME = join(homedir(), ".husk");
+const HUSK_HOME = process.env.HUSK_HOME ?? join(homedir(), ".husk");
 
 export const paths = {
 	home: HUSK_HOME,

--- a/cli/src/lib/server.ts
+++ b/cli/src/lib/server.ts
@@ -7,7 +7,6 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { pipeline } from "node:stream/promises";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { paths } from "./paths.js";
@@ -68,7 +67,10 @@ export async function downloadServer(ref = "main"): Promise<void> {
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
-			fileStream.write(value);
+			const ok = fileStream.write(value);
+			if (!ok) {
+				await new Promise<void>((resolve) => fileStream.once("drain", resolve));
+			}
 			received += value.byteLength;
 
 			if (totalBytes > 0) {

--- a/cli/src/lib/service.ts
+++ b/cli/src/lib/service.ts
@@ -87,21 +87,42 @@ export function installService(bunPath: string, configPath: string): boolean {
 	}
 }
 
-function installLaunchd(bunPath: string, configPath: string): boolean {
-	// Unload existing if present
-	if (existsSync(paths.launchdPlist)) {
+function launchctlBootout(plistPath: string): void {
+	try {
+		const uid = execSync("id -u", { encoding: "utf-8" }).trim();
+		execSync(`launchctl bootout gui/${uid} "${plistPath}"`, {
+			stdio: "pipe",
+		});
+	} catch {
+		// Fallback for older macOS
 		try {
-			execSync(`launchctl unload "${paths.launchdPlist}"`, {
-				stdio: "pipe",
-			});
+			execSync(`launchctl unload "${plistPath}"`, { stdio: "pipe" });
 		} catch {
 			// Not loaded, fine
 		}
 	}
+}
+
+function launchctlBootstrap(plistPath: string): void {
+	const uid = execSync("id -u", { encoding: "utf-8" }).trim();
+	try {
+		execSync(`launchctl bootstrap gui/${uid} "${plistPath}"`, {
+			stdio: "pipe",
+		});
+	} catch {
+		// Fallback for older macOS
+		execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" });
+	}
+}
+
+function installLaunchd(bunPath: string, configPath: string): boolean {
+	if (existsSync(paths.launchdPlist)) {
+		launchctlBootout(paths.launchdPlist);
+	}
 
 	mkdirSync(dirname(paths.launchdPlist), { recursive: true });
 	writeFileSync(paths.launchdPlist, launchdPlist(bunPath, configPath));
-	execSync(`launchctl load "${paths.launchdPlist}"`, { stdio: "pipe" });
+	launchctlBootstrap(paths.launchdPlist);
 	p.log.success("Installed launchd service (starts on boot)");
 	return true;
 }
@@ -120,9 +141,7 @@ export function uninstallService(): boolean {
 
 	try {
 		if (os === "darwin" && existsSync(paths.launchdPlist)) {
-			execSync(`launchctl unload "${paths.launchdPlist}"`, {
-				stdio: "pipe",
-			});
+			launchctlBootout(paths.launchdPlist);
 			unlinkSync(paths.launchdPlist);
 			return true;
 		}
@@ -143,9 +162,7 @@ export function startService(): boolean {
 	const os = platform();
 	try {
 		if (os === "darwin" && existsSync(paths.launchdPlist)) {
-			execSync(`launchctl load "${paths.launchdPlist}"`, {
-				stdio: "pipe",
-			});
+			launchctlBootstrap(paths.launchdPlist);
 			return true;
 		}
 		if (os === "linux" && existsSync(paths.systemdUnit)) {
@@ -162,9 +179,7 @@ export function stopService(): boolean {
 	const os = platform();
 	try {
 		if (os === "darwin" && existsSync(paths.launchdPlist)) {
-			execSync(`launchctl unload "${paths.launchdPlist}"`, {
-				stdio: "pipe",
-			});
+			launchctlBootout(paths.launchdPlist);
 			return true;
 		}
 		if (os === "linux" && existsSync(paths.systemdUnit)) {


### PR DESCRIPTION
Zod validation in credentials.ts. readCredentials() validates parsed JSON through schema (returns null on bad shape), setupAdmin() validates the API key response instead of unsafe `as` cast.

HUSK_HOME env override in paths.ts. All paths derive from process.env.HUSK_HOME when set, useful for testing and non-standard installs.

Modern launchctl in service.ts. bootstrap/bootout with try/catch fallback to legacy load/unload for older macOS.

Backpressure fix in server.ts. downloadServer write loop now awaits drain when the write buffer is full. Removed unused pipeline import.