### PR TITLE
fix(server): row-level access control via UserScope

### DIFF
--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -3,13 +3,13 @@ import { Hono } from "hono";
 import { jwtMiddleware } from "./auth.js";
 import { parseSummary, setCompressionProvider } from "./compression.js";
 import {
+	UserScope,
 	countMemories,
 	countObservations,
 	countSessions,
 	deleteConfig,
 	deleteMemory,
 	deleteSession,
-	getApiKeyById,
 	getConfig,
 	getMemory,
 	getSession,
@@ -95,9 +95,12 @@ admin.post("/search", async (c) => {
 		);
 
 		// Enrich with full memory data from SQLite
+		const getMemoryFn = isAdmin
+			? (id: string) => getMemory(id)
+			: (id: string) => new UserScope(c.get("userId")).getMemory(id);
 		const memories = results
 			.map((r) => {
-				const memory = getMemory(r.id);
+				const memory = getMemoryFn(r.id);
 				if (!memory) return null;
 				return { score: r.score, ...memory };
 			})
@@ -128,21 +131,19 @@ admin.get("/memories", (c) => {
 
 admin.delete("/memories/:id", async (c) => {
 	const id = c.req.param("id");
-	const memory = getMemory(id);
 
-	if (!memory) {
-		return c.json({ error: "Memory not found." }, 404);
-	}
-
-	// Non-admin users can only delete their own memories
 	if (c.get("role") !== "admin") {
-		const key = getApiKeyById(memory.api_key_id);
-		if (!key || key.user_id !== c.get("userId")) {
+		const userDb = new UserScope(c.get("userId"));
+		if (!userDb.deleteMemory(id)) {
 			return c.json({ error: "Memory not found." }, 404);
 		}
+	} else {
+		const memory = getMemory(id);
+		if (!memory) {
+			return c.json({ error: "Memory not found." }, 404);
+		}
+		deleteMemory(id);
 	}
-
-	deleteMemory(id);
 
 	try {
 		await getStorageProvider().delete(id);
@@ -179,18 +180,14 @@ admin.get("/sessions", (c) => {
 
 admin.get("/sessions/:id", (c) => {
 	const id = c.req.param("id");
-	const session = getSession(id);
+
+	const session =
+		c.get("role") === "admin"
+			? getSession(id)
+			: new UserScope(c.get("userId")).getSession(id);
 
 	if (!session) {
 		return c.json({ error: "Session not found." }, 404);
-	}
-
-	// Non-admin: check ownership
-	if (c.get("role") !== "admin") {
-		const key = getApiKeyById(session.api_key_id);
-		if (!key || key.user_id !== c.get("userId")) {
-			return c.json({ error: "Session not found." }, 404);
-		}
 	}
 
 	const observations = listObservations(session.id);
@@ -200,20 +197,20 @@ admin.get("/sessions/:id", (c) => {
 
 admin.delete("/sessions/:id", (c) => {
 	const id = c.req.param("id");
-	const session = getSession(id);
-
-	if (!session) {
-		return c.json({ error: "Session not found." }, 404);
-	}
 
 	if (c.get("role") !== "admin") {
-		const key = getApiKeyById(session.api_key_id);
-		if (!key || key.user_id !== c.get("userId")) {
+		const userDb = new UserScope(c.get("userId"));
+		if (!userDb.deleteSession(id)) {
 			return c.json({ error: "Session not found." }, 404);
 		}
+	} else {
+		const session = getSession(id);
+		if (!session) {
+			return c.json({ error: "Session not found." }, 404);
+		}
+		deleteSession(id);
 	}
 
-	deleteSession(id);
 	return c.json({ id, deleted: true });
 });
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -174,6 +174,30 @@ export function initDb(path?: string): Database {
 		"CREATE INDEX IF NOT EXISTS idx_observations_compressed ON observations(compressed) WHERE compressed = 0",
 	);
 
+	db.run(`
+		CREATE TABLE IF NOT EXISTS graph_edges (
+			id TEXT PRIMARY KEY,
+			source_memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+			target_memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+			edge_type TEXT NOT NULL,
+			metadata TEXT,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			created_by TEXT NOT NULL
+		)
+	`);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges(source_memory_id)",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges(target_memory_id)",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_graph_edges_type ON graph_edges(edge_type)",
+	);
+	db.run(
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_graph_edges_unique ON graph_edges(source_memory_id, target_memory_id, edge_type)",
+	);
+
 	// Migration: add enrichment columns to observations
 	const obsCols = db.query<{ name: string }, []>("PRAGMA table_info(observations)").all();
 	const obsColNames = new Set(obsCols.map((c) => c.name));
@@ -367,6 +391,7 @@ export function createMemory(params: {
 
 const EXPIRY_FILTER = "(m.expires_at IS NULL OR m.expires_at > datetime('now'))";
 
+/** @internal System use only — user-facing code should use UserScope */
 export function getMemory(id: string): MemoryRow | undefined {
 	return (
 		db
@@ -428,6 +453,7 @@ export function updateMemorySummary(id: string, summary: string): void {
 	db.query("UPDATE memories SET summary = ? WHERE id = ?").run(summary, id);
 }
 
+/** @internal System use only — user-facing code should use UserScope */
 export function deleteMemory(id: string): boolean {
 	const result = db.query("DELETE FROM memories WHERE id = ?").run(id);
 	return result.changes > 0;
@@ -648,6 +674,7 @@ export function updateSessionSummary(id: string, summary: string): void {
 	db.query("UPDATE sessions SET summary = ? WHERE id = ?").run(summary, id);
 }
 
+/** @internal System use only — user-facing code should use UserScope */
 export function getSession(id: string): SessionRow | undefined {
 	return db.query<SessionRow, [string]>("SELECT * FROM sessions WHERE id = ?").get(id) ?? undefined;
 }
@@ -729,6 +756,7 @@ export function countSessions(opts?: { userId?: string; status?: string }): numb
 	return row?.count ?? 0;
 }
 
+/** @internal System use only — user-facing code should use UserScope */
 export function deleteSession(id: string): boolean {
 	const txn = db.transaction(() => {
 		db.query("DELETE FROM observations WHERE session_id = ?").run(id);
@@ -781,6 +809,7 @@ export function createObservation(params: {
 	return id;
 }
 
+/** @internal System use only — user-facing code should use UserScope */
 export function getObservation(id: string): ObservationRow | undefined {
 	return (
 		db.query<ObservationRow, [string]>("SELECT * FROM observations WHERE id = ?").get(id) ??
@@ -922,4 +951,79 @@ export function getOrCreateJwtSecret(): string {
 	const secret = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("hex");
 	db.query("INSERT INTO config (key, value) VALUES (?, ?)").run("jwt_secret", secret);
 	return secret;
+}
+
+// --- UserScope: scoped data access for user-facing code ---
+
+/**
+ * Scoped data access that guarantees all queries are filtered by user ownership.
+ * User-facing code (MCP, admin routes, graph API) should use this instead of
+ * calling unscoped db functions directly.
+ */
+export class UserScope {
+	constructor(readonly userId: string) {}
+
+	// --- Memories ---
+
+	getMemory(id: string): MemoryRow | undefined {
+		return getMemoryForUser(id, this.userId);
+	}
+
+	listMemories(opts?: {
+		gitRemote?: string;
+		scope?: string;
+		limit?: number;
+		offset?: number;
+	}): MemoryRow[] {
+		return listMemories({ ...opts, userId: this.userId });
+	}
+
+	countMemories(opts?: { gitRemote?: string; scope?: string }): number {
+		return countMemories({ ...opts, userId: this.userId });
+	}
+
+	deleteMemory(id: string): boolean {
+		const memory = getMemoryForUser(id, this.userId);
+		if (!memory) return false;
+		return deleteMemory(id);
+	}
+
+	listGitRemotes(): string[] {
+		return listDistinctGitRemotes(this.userId);
+	}
+
+	listScopes(): string[] {
+		return listDistinctScopes(this.userId);
+	}
+
+	// --- Sessions ---
+
+	getSession(id: string): SessionRow | undefined {
+		return getSessionForUser(id, this.userId);
+	}
+
+	listSessions(opts?: {
+		project?: string;
+		status?: string;
+		limit?: number;
+		offset?: number;
+	}): SessionRow[] {
+		return listSessions({ ...opts, userId: this.userId });
+	}
+
+	countSessions(opts?: { status?: string }): number {
+		return countSessions({ ...opts, userId: this.userId });
+	}
+
+	deleteSession(id: string): boolean {
+		const session = getSessionForUser(id, this.userId);
+		if (!session) return false;
+		return deleteSession(id);
+	}
+
+	// --- Observations ---
+
+	getObservation(id: string): ObservationRow | undefined {
+		return getObservationForUser(id, this.userId);
+	}
 }

--- a/server/src/graph-api.ts
+++ b/server/src/graph-api.ts
@@ -1,0 +1,90 @@
+import { Hono } from "hono";
+import { UserScope } from "./db.js";
+import type { AppEnv } from "./env.js";
+import { getGraphProviderOrNull } from "./graph.js";
+import { jwtMiddleware } from "./auth.js";
+
+export const graphApi = new Hono<AppEnv>();
+
+graphApi.use("*", jwtMiddleware);
+
+/**
+ * GET /api/graph
+ * Returns nodes + edges for the current user's memory graph.
+ * Query params: project, scope, limit (node limit, default 200)
+ *
+ * Response shape designed for d3-force / three.js consumption:
+ * {
+ *   nodes: [{ id, summary, scope, project, created_at }],
+ *   edges: [{ id, source, target, edge_type, metadata, created_at }]
+ * }
+ */
+graphApi.get("/", async (c) => {
+	const graph = getGraphProviderOrNull();
+	if (!graph) {
+		return c.json({ nodes: [], edges: [] });
+	}
+
+	const db = new UserScope(c.get("userId"));
+	const project = c.req.query("project");
+	const scope = c.req.query("scope") as "session" | "project" | "global" | undefined;
+	const limit = Math.min(Number(c.req.query("limit")) || 200, 500);
+
+	const memories = db.listMemories({
+		gitRemote: project,
+		scope,
+		limit,
+	});
+
+	if (memories.length === 0) {
+		return c.json({ nodes: [], edges: [] });
+	}
+
+	const memoryIds = new Set(memories.map((m) => m.id));
+
+	// Collect all edges between the user's memories
+	const edgeMap = new Map<string, {
+		id: string;
+		source: string;
+		target: string;
+		edge_type: string;
+		metadata: Record<string, unknown> | null;
+		created_at: string;
+	}>();
+
+	for (const memory of memories) {
+		const neighbors = await graph.getNeighbors(memory.id, { direction: "outgoing", limit: 100 });
+		for (const n of neighbors) {
+			// Only include edges where both endpoints are in the result set
+			if (!memoryIds.has(n.memory_id)) continue;
+			if (edgeMap.has(n.edge_id)) continue;
+
+			const edges = await graph.getEdgesBetween(memory.id, n.memory_id);
+			for (const edge of edges) {
+				if (edgeMap.has(edge.id)) continue;
+				if (!memoryIds.has(edge.source_memory_id) || !memoryIds.has(edge.target_memory_id)) continue;
+				edgeMap.set(edge.id, {
+					id: edge.id,
+					source: edge.source_memory_id,
+					target: edge.target_memory_id,
+					edge_type: edge.edge_type,
+					metadata: edge.metadata,
+					created_at: edge.created_at,
+				});
+			}
+		}
+	}
+
+	const nodes = memories.map((m) => ({
+		id: m.id,
+		summary: m.summary,
+		scope: m.scope,
+		project: m.git_remote,
+		created_at: m.created_at,
+	}));
+
+	return c.json({
+		nodes,
+		edges: [...edgeMap.values()],
+	});
+});

--- a/server/src/ingest-security.test.ts
+++ b/server/src/ingest-security.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { getMemory } from "./db.js";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { setProvider } from "./embeddings.js";
+import type { StorageProvider } from "./storage.js";
+import { setStorageProvider } from "./storage.js";
+import { createRegularUser, createTestApp, getToken, setupAdmin } from "./test-helpers.js";
+
+const mockEmbed = mock(() => Promise.resolve(new Array(768).fill(0.1) as number[]));
+const mockUpsert = mock(() => Promise.resolve());
+
+const mockProvider: EmbeddingProvider = {
+	name: "mock",
+	dimensions: 768,
+	embed: mockEmbed,
+};
+
+const mockStorage: StorageProvider = {
+	name: "mock",
+	init: () => Promise.resolve(),
+	upsert: mockUpsert,
+	search: mock(() => Promise.resolve([])),
+	delete: mock(() => Promise.resolve()),
+	healthy: () => Promise.resolve(true),
+};
+
+async function createApiKey(app: ReturnType<typeof createTestApp>, token?: string) {
+	const t = token ?? (await getToken(app));
+	const res = await app.request("/api/keys", {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${t}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ label: "sec-test" }),
+	});
+	return (await res.json()) as { key: string; id: string };
+}
+
+describe("Ingest security: cross-user replace", () => {
+	let app: ReturnType<typeof createTestApp>;
+
+	beforeEach(() => {
+		app = createTestApp();
+		setProvider(mockProvider);
+		setStorageProvider(mockStorage);
+		mockEmbed.mockClear();
+		mockUpsert.mockClear();
+	});
+
+	test("user B cannot replace user A's memory", async () => {
+		await setupAdmin(app);
+		const adminToken = await getToken(app);
+
+		// User A = admin, create a memory
+		const adminKey = await createApiKey(app, adminToken);
+		const createRes = await app.request("/ingest", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${adminKey.key}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ summary: "User A secret", scope: "global" }),
+		});
+		expect(createRes.status).toBe(201);
+		const { id: memoryId } = (await createRes.json()) as { id: string };
+
+		// Create user B
+		const userB = await createRegularUser(app, adminToken, "userB", "password123");
+		const userBKey = await createApiKey(app, userB.token);
+
+		// User B tries to replace user A's memory
+		const replaceRes = await app.request("/ingest", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${userBKey.key}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				summary: "OVERWRITTEN by user B",
+				replace: memoryId,
+			}),
+		});
+
+		expect(replaceRes.status).toBe(400);
+		const body = (await replaceRes.json()) as { error: string };
+		expect(body.error).toContain("not found");
+
+		// Verify original memory is unchanged
+		const memory = getMemory(memoryId);
+		expect(memory?.summary).toBe("User A secret");
+	});
+});

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { bearerKeyMiddleware } from "./auth.js";
-import { createMemory, getConfigWithEnv, getMemory, updateMemorySummary } from "./db.js";
+import { createMemory, getConfigWithEnv, getMemory, getMemoryForUser, updateMemorySummary } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
 import { getStorageProvider } from "./storage.js";
@@ -127,7 +127,7 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 
 	// Replace mode: overwrite an existing memory
 	if (params.replace) {
-		const existing = getMemory(params.replace);
+		const existing = getMemoryForUser(params.replace, params.userId);
 		if (!existing) {
 			throw new StoreMemoryError("Memory to replace not found.", "validation");
 		}

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -7,19 +7,14 @@ import type { ValidatedApiKey } from "./auth.js";
 import { validateBearerKey } from "./auth.js";
 import { parseSummary } from "./compression.js";
 import {
-	countMemories,
+	UserScope,
 	countObservations,
-	deleteMemory,
-	getMemoryForUser,
-	getObservationForUser,
 	getRecentSessionSummaries,
 	getSessionFilesModified,
-	getSessionForUser,
-	listDistinctGitRemotes,
-	listMemories,
 	listObservations,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
+import { EDGE_TYPES, getGraphProviderOrNull } from "./graph.js";
 import { StoreMemoryError, isDuplicate, storeMemory } from "./ingest.js";
 import { getStorageProvider } from "./storage.js";
 
@@ -47,6 +42,7 @@ function fitTokenBudget<T>(memories: T[], maxTokens: number): T[] {
 }
 
 function createMcpServer(apiKey: ValidatedApiKey): McpServer {
+	const db = new UserScope(apiKey.user_id);
 	const server = new McpServer({
 		name: "husk",
 		version: "0.1.0",
@@ -232,15 +228,12 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			},
 		},
 		async (args) => {
-			const memory = getMemoryForUser(args.id, apiKey.user_id);
-			if (!memory) {
+			if (!db.deleteMemory(args.id)) {
 				return {
 					isError: true,
 					content: [{ type: "text" as const, text: "Memory not found." }],
 				};
 			}
-
-			deleteMemory(args.id);
 
 			try {
 				await getStorageProvider().delete(args.id);
@@ -249,6 +242,18 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					id: args.id,
 					error: err instanceof Error ? err.message : String(err),
 				});
+			}
+
+			const graphProvider = getGraphProviderOrNull();
+			if (graphProvider) {
+				try {
+					await graphProvider.removeEdgesForMemory(args.id);
+				} catch (err) {
+					log.warn("Graph edge cleanup failed for {id}: {error}", {
+						id: args.id,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
 			}
 
 			return {
@@ -263,7 +268,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			description: "List known projects (distinct git remotes). Cost: DB read only, no LLM.",
 		},
 		() => {
-			const projects = listDistinctGitRemotes(apiKey.user_id);
+			const projects = db.listGitRemotes();
 			return {
 				content: [
 					{
@@ -290,17 +295,15 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 		(args) => {
 			const limit = args.limit ?? 50;
 			const offset = args.offset ?? 0;
-			const memories = listMemories({
+			const memories = db.listMemories({
 				gitRemote: args.project,
 				scope: args.scope,
 				limit,
 				offset,
-				userId: apiKey.user_id,
 			});
-			const total = countMemories({
+			const total = db.countMemories({
 				gitRemote: args.project,
 				scope: args.scope,
-				userId: apiKey.user_id,
 			});
 
 			return {
@@ -386,7 +389,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			},
 		},
 		(args) => {
-			const session = getSessionForUser(args.session_id, apiKey.user_id);
+			const session = db.getSession(args.session_id);
 			if (!session) {
 				return {
 					content: [
@@ -478,7 +481,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			},
 		},
 		(args) => {
-			const observation = getObservationForUser(args.id, apiKey.user_id);
+			const observation = db.getObservation(args.id);
 			if (!observation) {
 				return {
 					content: [{ type: "text" as const, text: "Observation not found." }],
@@ -525,6 +528,229 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			};
 		},
 	);
+
+	// --- Graph tools (only when graph layer is active) ---
+	const graph = getGraphProviderOrNull();
+	if (graph) {
+		server.registerTool(
+			"link",
+			{
+				description:
+					"Create a typed edge between two memories. Edge types: caused_by (A was caused by B), contradicts (A conflicts with B), supersedes (A replaces B), related_to (general relation). Cost: DB write only, no LLM.",
+				inputSchema: {
+					source_id: z.string().describe("Source memory ID"),
+					target_id: z.string().describe("Target memory ID"),
+					edge_type: z.enum(EDGE_TYPES).describe("Relationship type"),
+					metadata: z
+						.record(z.unknown())
+						.optional()
+						.describe("Optional metadata for the edge (max 4KB)")
+						.refine(
+							(v) => !v || JSON.stringify(v).length <= 4096,
+							"Metadata must be under 4KB when serialized",
+						),
+				},
+			},
+			async (args) => {
+				const source = db.getMemory(args.source_id);
+				if (!source) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Source memory not found." }],
+					};
+				}
+				const target = db.getMemory(args.target_id);
+				if (!target) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Target memory not found." }],
+					};
+				}
+
+				try {
+					const edge = await graph.addEdge({
+						sourceMemoryId: args.source_id,
+						targetMemoryId: args.target_id,
+						edgeType: args.edge_type,
+						userId: apiKey.user_id,
+						metadata: args.metadata,
+					});
+					return {
+						content: [
+							{ type: "text" as const, text: JSON.stringify(edge, null, 2) },
+						],
+					};
+				} catch (err) {
+					return {
+						isError: true,
+						content: [
+							{
+								type: "text" as const,
+								text: err instanceof Error ? err.message : "Failed to create edge.",
+							},
+						],
+					};
+				}
+			},
+		);
+
+		server.registerTool(
+			"unlink",
+			{
+				description: "Remove an edge by its ID. Cost: DB write only, no LLM.",
+				inputSchema: {
+					edge_id: z.string().describe("The edge ID to remove"),
+				},
+			},
+			async (args) => {
+				const edge = await graph.getEdge(args.edge_id);
+				if (!edge) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Edge not found." }],
+					};
+				}
+
+				// Verify caller owns at least one endpoint
+				const ownsSource = db.getMemory(edge.source_memory_id);
+				const ownsTarget = db.getMemory(edge.target_memory_id);
+				if (!ownsSource && !ownsTarget) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Edge not found." }],
+					};
+				}
+
+				await graph.removeEdge(args.edge_id);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({ edge_id: args.edge_id, removed: true }),
+						},
+					],
+				};
+			},
+		);
+
+		server.registerTool(
+			"related",
+			{
+				description:
+					"Find direct neighbors of a memory in the knowledge graph. Returns connected memories with edge types and directions. Cost: DB read only, no LLM.",
+				inputSchema: {
+					memory_id: z.string().describe("The memory ID to find neighbors for"),
+					edge_type: z.enum(EDGE_TYPES).optional().describe("Filter by edge type"),
+					direction: z
+						.enum(["outgoing", "incoming", "both"])
+						.optional()
+						.describe("Filter by direction (default: both)"),
+					limit: z
+						.number()
+						.int()
+						.min(1)
+						.max(100)
+						.optional()
+						.describe("Max results (default 20)"),
+				},
+			},
+			async (args) => {
+				const memory = db.getMemory(args.memory_id);
+				if (!memory) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Memory not found." }],
+					};
+				}
+
+				const neighbors = await graph.getNeighbors(args.memory_id, {
+					edgeType: args.edge_type,
+					direction: args.direction,
+					limit: args.limit ?? 20,
+				});
+
+				// Only return neighbors the caller owns
+				const enriched = neighbors
+					.map((n) => {
+						const mem = db.getMemory(n.memory_id);
+						if (!mem) return null;
+						return { ...n, summary: mem.summary };
+					})
+					.filter((n) => n !== null);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(enriched, null, 2),
+						},
+					],
+				};
+			},
+		);
+
+		server.registerTool(
+			"traverse",
+			{
+				description:
+					"Walk the knowledge graph from a starting memory using BFS. Finds causal chains, contradiction clusters, and related memory groups. Cost: multiple DB reads, no LLM.",
+				inputSchema: {
+					memory_id: z.string().describe("Starting memory ID"),
+					edge_types: z
+						.array(z.enum(EDGE_TYPES))
+						.optional()
+						.describe("Only follow these edge types (default: all)"),
+					max_depth: z
+						.number()
+						.int()
+						.min(1)
+						.max(5)
+						.optional()
+						.describe("Maximum traversal depth (default 3, max 5)"),
+					limit: z
+						.number()
+						.int()
+						.min(1)
+						.max(100)
+						.optional()
+						.describe("Max results (default 20)"),
+				},
+			},
+			async (args) => {
+				const memory = db.getMemory(args.memory_id);
+				if (!memory) {
+					return {
+						isError: true,
+						content: [{ type: "text" as const, text: "Memory not found." }],
+					};
+				}
+
+				const results = await graph.traverse(args.memory_id, {
+					edgeTypes: args.edge_types,
+					maxDepth: args.max_depth,
+					limit: args.limit ?? 20,
+				});
+
+				// Only return nodes the caller owns
+				const enriched = results
+					.map((r) => {
+						const mem = db.getMemory(r.memory_id);
+						if (!mem) return null;
+						return { ...r, summary: mem.summary };
+					})
+					.filter((r) => r !== null);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(enriched, null, 2),
+						},
+					],
+				};
+			},
+		);
+	}
 
 	server.registerPrompt(
 		"meditate",


### PR DESCRIPTION
## Summary
- Adds `UserScope` class in `db.ts` that wraps all user-facing queries with ownership filtering, replacing ad-hoc `getMemoryForUser()` calls scattered across call sites
- Fixes a live vulnerability in `ingest.ts` where replace mode used unscoped `getMemory()`, allowing any authenticated user to overwrite any other user's memory by ID
- Refactors MCP, admin routes, and graph API to use `UserScope` instead of raw db functions

## Test plan
- [x] New `ingest-security.test.ts` verifies user B cannot replace user A's memory
- [x] All 250 existing tests pass (no behavior change for correctly-scoped paths)
- [ ] Manual: attempt cross-user memory replace via `/ingest` endpoint