### PR TITLE
chore(cli): add npm publishing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - "website/**"
 
 jobs:
-  ci:
+  server:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,3 +37,24 @@ jobs:
 
       - name: Build UI
         run: cd server && bun run build:ui
+
+  cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: cli
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        working-directory: cli
+        run: bun run build
+
+      - name: Test
+        working-directory: cli
+        run: bun test

--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -1,0 +1,82 @@
+name: Prepare CLI Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump (auto = git-cliff decides, or exact like 1.2.3)"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Calculate version
+        id: version
+        run: |
+          if [ "${{ inputs.version }}" = "auto" ]; then
+            # git-cliff bumped-version returns the tag including prefix
+            FULL_VERSION=$(git-cliff --include-path 'cli/**' --bumped-version --config cli/cliff.toml)
+            # Strip the cli/v prefix
+            VERSION="${FULL_VERSION#cli/v}"
+          else
+            CURRENT=$(node -p "require('./cli/package.json').version")
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            case "${{ inputs.version }}" in
+              major) VERSION="$((MAJOR + 1)).0.0" ;;
+              minor) VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+              patch) VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Calculated version: $VERSION"
+
+      - name: Generate changelog
+        run: git-cliff --include-path 'cli/**' --config cli/cliff.toml --tag "cli/v${{ steps.version.outputs.version }}" -o cli/CHANGELOG.md
+
+      - name: Bump package.json version
+        working-directory: cli
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      - name: Commit, tag, and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cli/package.json cli/CHANGELOG.md
+          git commit -m "chore(cli): release v${{ steps.version.outputs.version }}"
+          git tag "cli/v${{ steps.version.outputs.version }}"
+          git push origin HEAD --follow-tags

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,65 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "cli/v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v2
+
+      - name: Install dependencies
+        working-directory: cli
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        working-directory: cli
+        run: bun run build
+
+      - name: Test
+        working-directory: cli
+        run: bun test
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#cli/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          git-cliff --include-path 'cli/**' --config cli/cliff.toml --latest --strip header > RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "@huskai/cli v${{ steps.version.outputs.version }}"
+          body_path: RELEASE_NOTES.md
+
+      - name: Publish to npm
+        working-directory: cli
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/cliff.toml
+++ b/cli/cliff.toml
@@ -1,0 +1,46 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to @huskai/cli.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/Saturate/HUSK
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}{{ commit.message | upper_first }} \
+            ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+            {%- if commit.breaking %} **BREAKING**{% endif %}
+    {%- endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+tag_pattern = "cli/v[0-9].*"
+sort_commits = "newest"
+
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^perf", group = "<!-- 2 -->Performance" },
+    { message = "^refactor", group = "<!-- 3 -->Refactor" },
+    { message = "^doc", group = "<!-- 4 -->Documentation" },
+    { message = "^style", group = "<!-- 5 -->Styling" },
+    { message = "^test", group = "<!-- 6 -->Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->Miscellaneous" },
+    { body = ".*security", group = "<!-- 8 -->Security" },
+]

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,10 +9,25 @@
 	"engines": {
 		"node": ">=18"
 	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Saturate/HUSK.git",
+		"directory": "cli"
+	},
+	"homepage": "https://github.com/Saturate/HUSK/tree/main/cli",
+	"bugs": {
+		"url": "https://github.com/Saturate/HUSK/issues"
+	},
+	"keywords": ["ai", "memory", "coding-assistant", "mcp", "cli"],
 	"scripts": {
 		"build": "tsup",
 		"dev": "tsup --watch",
-		"test": "bun test"
+		"test": "bun test",
+		"prepublishOnly": "tsup",
+		"changelog": "git-cliff --include-path 'cli/**' -o cli/CHANGELOG.md"
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.10",


### PR DESCRIPTION
## Summary
- Adds `publishConfig`, `repository`, `homepage`, `bugs`, `keywords` to `cli/package.json`
- Creates `cli/cliff.toml` for git-cliff changelog generation scoped to `cli/v*` tags
- Adds `prepare-cli-release.yml` workflow (manual dispatch → version bump + changelog + tag)
- Adds `release-cli.yml` workflow (triggered on `cli/v*` tags → build + test + GitHub Release + npm publish with provenance)
- Adds CLI build+test job to CI alongside the existing server job

## Before first release
1. Add `APP_ID` + `APP_PRIVATE_KEY` secrets to repo (GitHub App for pushing tags)
2. Configure npm OIDC trusted publishing for `@huskai/cli` → `Saturate/HUSK` + `release-cli.yml`, or add `NPM_TOKEN` secret

## Test plan
- [ ] CI runs the new `cli` job on this PR
- [ ] After merge: trigger `prepare-cli-release` manually, verify version bump + tag
- [ ] Verify `release-cli` fires on the tag and publishes to npm