### PR TITLE
fix(docker): allow website/package.json through .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ server/data/
 .git/
 .claude/
 website/
+!website/package.json
 **/*.test.ts
 server/seed.sh
 PLAN.md


### PR DESCRIPTION
## Summary
- `.dockerignore` excludes `website/` but the Dockerfile needs `website/package.json` for bun workspace lockfile resolution
- Adds `!website/package.json` exception to unblock Docker builds on main

This has been failing since #14.