### PR TITLE
fix(docker): add cli/package.json for bun workspace resolution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@ server/data/
 *.db-shm
 .git/
 .claude/
+cli/
+!cli/package.json
 website/
 !website/package.json
 **/*.test.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # files so bun can resolve the lockfile correctly
 COPY package.json bun.lock ./
 COPY server/package.json server/package.json
+COPY cli/package.json cli/package.json
 COPY plugins/claude-code/package.json plugins/claude-code/package.json
 COPY website/package.json website/package.json
 RUN bun install --frozen-lockfile
@@ -27,6 +28,7 @@ WORKDIR /app
 
 COPY package.json bun.lock ./
 COPY server/package.json server/package.json
+COPY cli/package.json cli/package.json
 COPY plugins/claude-code/package.json plugins/claude-code/package.json
 COPY website/package.json website/package.json
 RUN bun install --frozen-lockfile --production


### PR DESCRIPTION
## Summary
- Root `package.json` lists `cli` as a workspace but the Dockerfile didn't copy `cli/package.json`, causing `bun install` to fail
- Adds `COPY cli/package.json` to both build stages and `!cli/package.json` exception to `.dockerignore`

Fixes the Docker build failures on main since #14.