### PR TITLE
feat: workspace scope — group related projects with per-user access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ The server is **client-agnostic**. `/ingest` is a universal write endpoint - any
 
 ## Memory scopes
 
-| Scope     | What                   | Example                                                                              |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------ |
-| `session` | Single coding session  | "Migrated Stripe v2 to v3 - checkout and billing done, webhooks still need updating" |
-| `project` | Per-repo knowledge     | "Legacy API returns dates as DD/MM/YYYY, not ISO 8601 - parse with dayjs.utc()"     |
-| `global`  | Cross-project patterns | "Always use bun, not npm. Prefers biome over eslint+prettier"                        |
+| Scope       | What                        | Example                                                                              |
+| ----------- | --------------------------- | ------------------------------------------------------------------------------------ |
+| `session`   | Single coding session       | "Migrated Stripe v2 to v3 - checkout and billing done, webhooks still need updating" |
+| `project`   | Per-repo knowledge          | "Legacy API returns dates as DD/MM/YYYY, not ISO 8601 - parse with dayjs.utc()"     |
+| `workspace` | Shared across related repos | "All client-a repos use Postgres 15 with RLS policies"                               |
+| `global`    | Cross-project patterns      | "Always use bun, not npm. Prefers biome over eslint+prettier"                        |
 
-Projects are keyed by **git remote URL** - works across machines regardless of where the repo is checked out.
+Projects are keyed by **git remote URL** - works across machines regardless of where the repo is checked out. Workspaces group related projects so memories can be shared across repos in the same organization or client.
 
 ## Configuration
 

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -4,22 +4,34 @@ import { jwtMiddleware } from "./auth.js";
 import { parseSummary, setCompressionProvider } from "./compression.js";
 import {
 	UserScope,
+	assignProjectToWorkspace,
 	countMemories,
 	countObservations,
 	countSessions,
+	countWorkspaces,
+	createWorkspace,
 	deleteConfig,
 	deleteMemory,
 	deleteSession,
+	deleteWorkspace,
 	getConfig,
 	getMemory,
 	getSession,
+	getUserSetting,
+	getWorkspace,
+	getWorkspaceForUser,
 	listApiKeys,
 	listDistinctGitRemotes,
 	listDistinctScopes,
 	listMemories,
 	listObservations,
 	listSessions,
+	listWorkspaceProjects,
+	listWorkspaces,
+	removeProjectFromWorkspace,
 	setConfig,
+	setUserSetting,
+	updateWorkspace,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
@@ -50,6 +62,7 @@ admin.get("/stats", (c) => {
 		keys: { total: keys.length, active: activeKeys },
 		projects: projects.length,
 		sessions: { total: totalSessions, active: activeSessions },
+		workspaces: countWorkspaces(),
 	});
 });
 
@@ -228,6 +241,7 @@ const CONFIG_KEYS = [
 	"dedup_threshold",
 	"ttl_default_session",
 	"ttl_default_project",
+	"ttl_default_workspace",
 	"ttl_default_global",
 	"ttl_max",
 ] as const;
@@ -337,6 +351,7 @@ admin.put("/settings", async (c) => {
 		if (
 			(key === "ttl_default_session" ||
 				key === "ttl_default_project" ||
+				key === "ttl_default_workspace" ||
 				key === "ttl_default_global" ||
 				key === "ttl_max") &&
 			value !== null
@@ -371,6 +386,133 @@ admin.put("/settings", async (c) => {
 		resetPrivacyCache();
 	}
 
+	return c.json({ ok: true });
+});
+
+// --- Workspaces ---
+
+const WORKSPACE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/;
+
+function validateWorkspaceName(name: string): string | null {
+	if (!WORKSPACE_NAME_RE.test(name)) {
+		return "Name must be 1-63 characters: letters, numbers, hyphens, underscores, dots. Must start with a letter or number.";
+	}
+	return null;
+}
+
+admin.get("/workspaces", (c) => {
+	const userId = c.get("userId");
+	const isAdmin = c.get("role") === "admin";
+	const workspaces = listWorkspaces(isAdmin ? undefined : userId);
+	const result = workspaces.map((w) => ({
+		...w,
+		project_count: listWorkspaceProjects(w.id).length,
+	}));
+	return c.json({ workspaces: result });
+});
+
+admin.post("/workspaces", async (c) => {
+	const body = await c.req.json<{ name?: string }>();
+	const name = body.name?.trim();
+	if (!name) {
+		return c.json({ error: "Name is required." }, 400);
+	}
+	const nameError = validateWorkspaceName(name);
+	if (nameError) {
+		return c.json({ error: nameError }, 400);
+	}
+
+	try {
+		const id = createWorkspace(name, c.get("userId"));
+		return c.json({ id, name }, 201);
+	} catch {
+		return c.json({ error: "Workspace name already exists." }, 409);
+	}
+});
+
+admin.get("/workspaces/:id", (c) => {
+	const userId = c.get("userId");
+	const isAdmin = c.get("role") === "admin";
+	const ws = isAdmin
+		? getWorkspace(c.req.param("id"))
+		: getWorkspaceForUser(c.req.param("id"), userId);
+
+	if (!ws) return c.json({ error: "Not found." }, 404);
+
+	const projects = listWorkspaceProjects(ws.id);
+	return c.json({ ...ws, projects });
+});
+
+admin.put("/workspaces/:id", async (c) => {
+	const userId = c.get("userId");
+	const ws = getWorkspaceForUser(c.req.param("id"), userId);
+	if (!ws) return c.json({ error: "Not found." }, 404);
+
+	const body = await c.req.json<{ name?: string }>();
+	const name = body.name?.trim();
+	if (!name) {
+		return c.json({ error: "Name is required." }, 400);
+	}
+	const nameError = validateWorkspaceName(name);
+	if (nameError) {
+		return c.json({ error: nameError }, 400);
+	}
+
+	if (!updateWorkspace(ws.id, name)) {
+		return c.json({ error: "Not found." }, 404);
+	}
+	return c.json({ ok: true });
+});
+
+admin.delete("/workspaces/:id", (c) => {
+	const userId = c.get("userId");
+	const ws = getWorkspaceForUser(c.req.param("id"), userId);
+	if (!ws) return c.json({ error: "Not found." }, 404);
+
+	deleteWorkspace(ws.id);
+	return c.json({ id: ws.id, deleted: true });
+});
+
+admin.post("/workspaces/:id/projects", async (c) => {
+	const userId = c.get("userId");
+	const ws = getWorkspaceForUser(c.req.param("id"), userId);
+	if (!ws) return c.json({ error: "Not found." }, 404);
+
+	const body = await c.req.json<{ git_remote?: string }>();
+	const gitRemote = body.git_remote?.trim();
+	if (!gitRemote) {
+		return c.json({ error: "git_remote is required." }, 400);
+	}
+
+	assignProjectToWorkspace(ws.id, gitRemote);
+	return c.json({ workspace_id: ws.id, git_remote: gitRemote }, 201);
+});
+
+admin.delete("/workspaces/:id/projects/:remote", (c) => {
+	const userId = c.get("userId");
+	const ws = getWorkspaceForUser(c.req.param("id"), userId);
+	if (!ws) return c.json({ error: "Not found." }, 404);
+
+	const remote = decodeURIComponent(c.req.param("remote"));
+	if (!removeProjectFromWorkspace(remote)) {
+		return c.json({ error: "Not found." }, 404);
+	}
+	return c.json({ git_remote: remote, deleted: true });
+});
+
+// --- User Settings (workspace auto-detect) ---
+
+admin.get("/user-settings/workspace-auto-detect", (c) => {
+	const value = getUserSetting(c.get("userId"), "workspace_auto_detect");
+	return c.json({ enabled: value !== "false" });
+});
+
+admin.put("/user-settings/workspace-auto-detect", async (c) => {
+	const body = await c.req.json<{ enabled?: boolean }>();
+	if (typeof body.enabled !== "boolean") {
+		return c.json({ error: "enabled must be a boolean." }, 400);
+	}
+	setUserSetting(c.get("userId"), "workspace_auto_detect", String(body.enabled));
 	return c.json({ ok: true });
 });
 

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -19,6 +19,7 @@ import {
 	getSession,
 	getUserSetting,
 	getWorkspace,
+	getWorkspaceForProject,
 	getWorkspaceForUser,
 	listApiKeys,
 	listDistinctGitRemotes,
@@ -404,11 +405,7 @@ admin.get("/workspaces", (c) => {
 	const userId = c.get("userId");
 	const isAdmin = c.get("role") === "admin";
 	const workspaces = listWorkspaces(isAdmin ? undefined : userId);
-	const result = workspaces.map((w) => ({
-		...w,
-		project_count: listWorkspaceProjects(w.id).length,
-	}));
-	return c.json({ workspaces: result });
+	return c.json({ workspaces });
 });
 
 admin.post("/workspaces", async (c) => {
@@ -458,7 +455,7 @@ admin.put("/workspaces/:id", async (c) => {
 		return c.json({ error: nameError }, 400);
 	}
 
-	if (!updateWorkspace(ws.id, name)) {
+	if (!updateWorkspace(ws.id, name, userId)) {
 		return c.json({ error: "Not found." }, 404);
 	}
 	return c.json({ ok: true });
@@ -484,7 +481,16 @@ admin.post("/workspaces/:id/projects", async (c) => {
 		return c.json({ error: "git_remote is required." }, 400);
 	}
 
-	assignProjectToWorkspace(ws.id, gitRemote);
+	const existing = getWorkspaceForProject(gitRemote);
+	if (existing && existing.created_by !== userId) {
+		return c.json({ error: "Project is assigned to another user's workspace." }, 409);
+	}
+
+	try {
+		assignProjectToWorkspace(ws.id, gitRemote);
+	} catch {
+		return c.json({ error: "Project is already assigned to a workspace." }, 409);
+	}
 	return c.json({ workspace_id: ws.id, git_remote: gitRemote }, 201);
 });
 
@@ -494,7 +500,7 @@ admin.delete("/workspaces/:id/projects/:remote", (c) => {
 	if (!ws) return c.json({ error: "Not found." }, 404);
 
 	const remote = decodeURIComponent(c.req.param("remote"));
-	if (!removeProjectFromWorkspace(remote)) {
+	if (!removeProjectFromWorkspace(ws.id, remote)) {
 		return c.json({ error: "Not found." }, 404);
 	}
 	return c.json({ git_remote: remote, deleted: true });

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -466,8 +466,12 @@ admin.delete("/workspaces/:id", (c) => {
 	const ws = getWorkspaceForUser(c.req.param("id"), userId);
 	if (!ws) return c.json({ error: "Not found." }, 404);
 
-	deleteWorkspace(ws.id);
-	return c.json({ id: ws.id, deleted: true });
+	const result = deleteWorkspace(ws.id);
+	return c.json({
+		id: ws.id,
+		deleted: true,
+		rescoped_memories: result.rescopedMemories,
+	});
 });
 
 admin.post("/workspaces/:id/projects", async (c) => {

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -392,7 +392,7 @@ admin.put("/settings", async (c) => {
 
 // --- Workspaces ---
 
-const WORKSPACE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$/;
+const WORKSPACE_NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N}._-]{0,62}$/u;
 
 function validateWorkspaceName(name: string): string | null {
 	if (!WORKSPACE_NAME_RE.test(name)) {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -175,6 +175,44 @@ export function initDb(path?: string): Database {
 	);
 
 	db.run(`
+		CREATE TABLE IF NOT EXISTS workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT UNIQUE NOT NULL,
+			created_by TEXT NOT NULL REFERENCES users(id),
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`);
+
+	db.run(`
+		CREATE TABLE IF NOT EXISTS workspace_projects (
+			workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+			git_remote TEXT NOT NULL UNIQUE,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (workspace_id, git_remote)
+		)
+	`);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_workspace_projects_remote ON workspace_projects(git_remote)",
+	);
+
+	// Migration: add workspace_id to memories
+	if (!memCols.some((c) => c.name === "workspace_id")) {
+		db.run(
+			"ALTER TABLE memories ADD COLUMN workspace_id TEXT REFERENCES workspaces(id) ON DELETE SET NULL",
+		);
+	}
+	db.run("CREATE INDEX IF NOT EXISTS idx_memories_workspace ON memories(workspace_id)");
+
+	db.run(`
+		CREATE TABLE IF NOT EXISTS user_settings (
+			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (user_id, key)
+		)
+	`);
+
+	db.run(`
 		CREATE TABLE IF NOT EXISTS graph_edges (
 			id TEXT PRIMARY KEY,
 			source_memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
@@ -358,6 +396,7 @@ export interface MemoryRow {
 	metadata: string | null;
 	created_at: string;
 	expires_at: string | null;
+	workspace_id: string | null;
 }
 
 export function createMemory(params: {
@@ -368,9 +407,10 @@ export function createMemory(params: {
 	summary: string;
 	metadata?: string | null;
 	expiresAt?: string | null;
+	workspaceId?: string | null;
 }): string {
 	db.query(
-		"INSERT INTO memories (id, api_key_id, git_remote, scope, summary, metadata, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		"INSERT INTO memories (id, api_key_id, git_remote, scope, summary, metadata, expires_at, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
 	).run(
 		params.id,
 		params.apiKeyId,
@@ -379,6 +419,7 @@ export function createMemory(params: {
 		params.summary,
 		params.metadata ?? null,
 		params.expiresAt ?? null,
+		params.workspaceId ?? null,
 	);
 	return params.id;
 }
@@ -531,6 +572,151 @@ export function countMemories(opts?: {
 
 	const row = db.query<{ count: number }, string[]>(sql).get(...params);
 	return row?.count ?? 0;
+}
+
+// --- User Settings ---
+
+export function getUserSetting(userId: string, key: string): string | undefined {
+	const row = db
+		.query<{ value: string }, [string, string]>(
+			"SELECT value FROM user_settings WHERE user_id = ? AND key = ?",
+		)
+		.get(userId, key);
+	return row?.value;
+}
+
+export function setUserSetting(userId: string, key: string, value: string): void {
+	db.query("INSERT OR REPLACE INTO user_settings (user_id, key, value) VALUES (?, ?, ?)").run(
+		userId,
+		key,
+		value,
+	);
+}
+
+export function deleteUserSetting(userId: string, key: string): boolean {
+	const result = db
+		.query("DELETE FROM user_settings WHERE user_id = ? AND key = ?")
+		.run(userId, key);
+	return result.changes > 0;
+}
+
+// --- Workspaces ---
+
+export interface WorkspaceRow {
+	id: string;
+	name: string;
+	created_by: string;
+	created_at: string;
+}
+
+export function createWorkspace(name: string, createdBy: string): string {
+	const id = crypto.randomUUID();
+	db.query("INSERT INTO workspaces (id, name, created_by) VALUES (?, ?, ?)").run(
+		id,
+		name,
+		createdBy,
+	);
+	return id;
+}
+
+export function getWorkspace(id: string): WorkspaceRow | undefined {
+	return (
+		db.query<WorkspaceRow, [string]>("SELECT * FROM workspaces WHERE id = ?").get(id) ?? undefined
+	);
+}
+
+export function getWorkspaceByName(name: string, userId?: string): WorkspaceRow | undefined {
+	if (userId) {
+		return (
+			db
+				.query<WorkspaceRow, [string, string]>(
+					"SELECT * FROM workspaces WHERE name = ? AND created_by = ?",
+				)
+				.get(name, userId) ?? undefined
+		);
+	}
+	return (
+		db.query<WorkspaceRow, [string]>("SELECT * FROM workspaces WHERE name = ?").get(name) ??
+		undefined
+	);
+}
+
+export function listWorkspaces(userId?: string): WorkspaceRow[] {
+	if (userId) {
+		return db
+			.query<WorkspaceRow, [string]>(
+				"SELECT * FROM workspaces WHERE created_by = ? ORDER BY name ASC",
+			)
+			.all(userId);
+	}
+	return db.query<WorkspaceRow, []>("SELECT * FROM workspaces ORDER BY name ASC").all();
+}
+
+export function updateWorkspace(id: string, name: string): boolean {
+	const result = db.query("UPDATE workspaces SET name = ? WHERE id = ?").run(name, id);
+	return result.changes > 0;
+}
+
+export function deleteWorkspace(id: string): boolean {
+	const result = db.query("DELETE FROM workspaces WHERE id = ?").run(id);
+	return result.changes > 0;
+}
+
+export function countWorkspaces(): number {
+	const row = db.query<{ count: number }, []>("SELECT COUNT(*) as count FROM workspaces").get();
+	return row?.count ?? 0;
+}
+
+export function assignProjectToWorkspace(workspaceId: string, gitRemote: string): void {
+	db.query(
+		"INSERT OR REPLACE INTO workspace_projects (workspace_id, git_remote) VALUES (?, ?)",
+	).run(workspaceId, gitRemote);
+}
+
+export function removeProjectFromWorkspace(gitRemote: string): boolean {
+	const result = db.query("DELETE FROM workspace_projects WHERE git_remote = ?").run(gitRemote);
+	return result.changes > 0;
+}
+
+export function listWorkspaceProjects(workspaceId: string): string[] {
+	const rows = db
+		.query<{ git_remote: string }, [string]>(
+			"SELECT git_remote FROM workspace_projects WHERE workspace_id = ? ORDER BY git_remote",
+		)
+		.all(workspaceId);
+	return rows.map((r) => r.git_remote);
+}
+
+export function getWorkspaceForUser(id: string, userId: string): WorkspaceRow | undefined {
+	return (
+		db
+			.query<WorkspaceRow, [string, string]>(
+				"SELECT * FROM workspaces WHERE id = ? AND created_by = ?",
+			)
+			.get(id, userId) ?? undefined
+	);
+}
+
+export function getWorkspaceForProject(
+	gitRemote: string,
+	userId?: string,
+): WorkspaceRow | undefined {
+	if (userId) {
+		return (
+			db
+				.query<WorkspaceRow, [string, string]>(
+					"SELECT w.* FROM workspaces w JOIN workspace_projects wp ON w.id = wp.workspace_id WHERE wp.git_remote = ? AND w.created_by = ?",
+				)
+				.get(gitRemote, userId) ?? undefined
+		);
+	}
+	return (
+		db
+			.query<WorkspaceRow, [string]>(
+				"SELECT w.* FROM workspaces w JOIN workspace_projects wp ON w.id = wp.workspace_id WHERE wp.git_remote = ?",
+			)
+			.get(gitRemote) ?? undefined
+	);
 }
 
 // --- Invites ---
@@ -1085,5 +1271,11 @@ export class UserScope {
 
 	validateObservationIds(ids: string[]): boolean {
 		return validateObservationIds(ids, this.userId);
+	}
+
+	// --- Workspaces ---
+
+	resolveWorkspaceForRemote(gitRemote: string): WorkspaceRow | undefined {
+		return getWorkspaceForProject(gitRemote, this.userId);
 	}
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -675,9 +675,22 @@ export function updateWorkspace(id: string, name: string, userId: string): boole
 	return result.changes > 0;
 }
 
-export function deleteWorkspace(id: string): boolean {
-	const result = db.query("DELETE FROM workspaces WHERE id = ?").run(id);
-	return result.changes > 0;
+/**
+ * Deletes a workspace, re-scoping any workspace-scoped memories to "project"
+ * so they remain findable. Returns the count of re-scoped memories.
+ */
+export function deleteWorkspace(id: string): { deleted: boolean; rescopedMemories: number } {
+	const txn = db.transaction(() => {
+		const rescoped = db
+			.query(
+				"UPDATE memories SET scope = 'project', workspace_id = NULL WHERE workspace_id = ? AND scope = 'workspace'",
+			)
+			.run(id);
+		db.query("UPDATE memories SET workspace_id = NULL WHERE workspace_id = ?").run(id);
+		const result = db.query("DELETE FROM workspaces WHERE id = ?").run(id);
+		return { deleted: result.changes > 0, rescopedMemories: rescoped.changes };
+	});
+	return txn();
 }
 
 export function countWorkspaces(): number {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -177,11 +177,14 @@ export function initDb(path?: string): Database {
 	db.run(`
 		CREATE TABLE IF NOT EXISTS workspaces (
 			id TEXT PRIMARY KEY,
-			name TEXT UNIQUE NOT NULL,
+			name TEXT NOT NULL,
 			created_by TEXT NOT NULL REFERENCES users(id),
 			created_at TEXT NOT NULL DEFAULT (datetime('now'))
 		)
 	`);
+	db.run(
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_name_user ON workspaces(name, created_by)",
+	);
 
 	db.run(`
 		CREATE TABLE IF NOT EXISTS workspace_projects (
@@ -318,6 +321,13 @@ export function deleteUser(id: string): boolean {
 		db.query("DELETE FROM api_keys WHERE user_id = ?").run(id);
 		// Delete invites created by this user
 		db.query("DELETE FROM invites WHERE created_by = ?").run(id);
+		// Delete workspace project assignments and workspaces
+		db.query(
+			"DELETE FROM workspace_projects WHERE workspace_id IN (SELECT id FROM workspaces WHERE created_by = ?)",
+		).run(id);
+		db.query("DELETE FROM workspaces WHERE created_by = ?").run(id);
+		// Delete user settings
+		db.query("DELETE FROM user_settings WHERE user_id = ?").run(id);
 		// Delete the user
 		const result = db.query("DELETE FROM users WHERE id = ?").run(id);
 		return result.changes > 0;
@@ -641,19 +651,27 @@ export function getWorkspaceByName(name: string, userId?: string): WorkspaceRow 
 	);
 }
 
-export function listWorkspaces(userId?: string): WorkspaceRow[] {
+export interface WorkspaceWithCount extends WorkspaceRow {
+	project_count: number;
+}
+
+export function listWorkspaces(userId?: string): WorkspaceWithCount[] {
+	const base =
+		"SELECT w.*, COUNT(wp.git_remote) as project_count FROM workspaces w LEFT JOIN workspace_projects wp ON w.id = wp.workspace_id";
 	if (userId) {
 		return db
-			.query<WorkspaceRow, [string]>(
-				"SELECT * FROM workspaces WHERE created_by = ? ORDER BY name ASC",
+			.query<WorkspaceWithCount, [string]>(
+				`${base} WHERE w.created_by = ? GROUP BY w.id ORDER BY w.name ASC`,
 			)
 			.all(userId);
 	}
-	return db.query<WorkspaceRow, []>("SELECT * FROM workspaces ORDER BY name ASC").all();
+	return db.query<WorkspaceWithCount, []>(`${base} GROUP BY w.id ORDER BY w.name ASC`).all();
 }
 
-export function updateWorkspace(id: string, name: string): boolean {
-	const result = db.query("UPDATE workspaces SET name = ? WHERE id = ?").run(name, id);
+export function updateWorkspace(id: string, name: string, userId: string): boolean {
+	const result = db
+		.query("UPDATE workspaces SET name = ? WHERE id = ? AND created_by = ?")
+		.run(name, id, userId);
 	return result.changes > 0;
 }
 
@@ -668,13 +686,16 @@ export function countWorkspaces(): number {
 }
 
 export function assignProjectToWorkspace(workspaceId: string, gitRemote: string): void {
-	db.query(
-		"INSERT OR REPLACE INTO workspace_projects (workspace_id, git_remote) VALUES (?, ?)",
-	).run(workspaceId, gitRemote);
+	db.query("INSERT INTO workspace_projects (workspace_id, git_remote) VALUES (?, ?)").run(
+		workspaceId,
+		gitRemote,
+	);
 }
 
-export function removeProjectFromWorkspace(gitRemote: string): boolean {
-	const result = db.query("DELETE FROM workspace_projects WHERE git_remote = ?").run(gitRemote);
+export function removeProjectFromWorkspace(workspaceId: string, gitRemote: string): boolean {
+	const result = db
+		.query("DELETE FROM workspace_projects WHERE workspace_id = ? AND git_remote = ?")
+		.run(workspaceId, gitRemote);
 	return result.changes > 0;
 }
 

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -11,7 +11,7 @@ import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
 import { getStorageProvider } from "./storage.js";
 
-const VALID_SCOPES = ["session", "project", "global"] as const;
+const VALID_SCOPES = ["session", "project", "workspace", "global"] as const;
 type Scope = (typeof VALID_SCOPES)[number];
 
 function isValidScope(scope: string): scope is Scope {
@@ -31,6 +31,7 @@ function getDedupThreshold(): number {
 const TTL_DEFAULTS: Record<string, string | undefined> = {
 	session: "2592000",
 	project: "7776000",
+	workspace: "7776000",
 	global: undefined,
 };
 
@@ -84,6 +85,7 @@ interface StoreMemoryParams {
 	force?: boolean;
 	replace?: string;
 	ttl?: number | null;
+	workspaceId?: string | null;
 }
 
 interface StoredMemory {
@@ -122,6 +124,7 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 	const gitRemote = params.gitRemote?.trim() || null;
 	const metadata = params.metadata ? JSON.stringify(params.metadata) : null;
 	const expiresAt = resolveExpiresAt(params.ttl, scope);
+	const workspaceId = params.workspaceId ?? null;
 
 	let vector: number[];
 	try {
@@ -149,6 +152,7 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 				api_key_label: params.apiKeyLabel,
 				created_at: existing.created_at,
 				expires_at: expiresAt,
+				workspace_id: workspaceId,
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "Unknown error";
@@ -197,6 +201,7 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 		summary: params.summary,
 		metadata,
 		expiresAt,
+		workspaceId,
 	});
 
 	try {
@@ -208,6 +213,7 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 			api_key_label: params.apiKeyLabel,
 			created_at: createdAt,
 			expires_at: expiresAt,
+			workspace_id: workspaceId,
 		});
 	} catch (err) {
 		const message = err instanceof Error ? err.message : "Unknown error";

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -5,11 +5,13 @@ import {
 	getConfigWithEnv,
 	getMemory,
 	getMemoryForUser,
+	getUserSetting,
 	updateMemorySummary,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
 import { getStorageProvider } from "./storage.js";
+import { resolveWorkspace } from "./workspace.js";
 
 const VALID_SCOPES = ["session", "project", "workspace", "global"] as const;
 type Scope = (typeof VALID_SCOPES)[number];
@@ -268,6 +270,17 @@ ingest.post("/", async (c) => {
 
 	const apiKey = c.get("apiKey");
 
+	// Resolve workspace for workspace-scoped memories
+	let workspaceId: string | null = null;
+	if (body.scope === "workspace" && body.git_remote) {
+		const autoDetect = getUserSetting(apiKey.user_id, "workspace_auto_detect") !== "false";
+		const ws = resolveWorkspace(body.git_remote, {
+			userId: apiKey.user_id,
+			autoDetect,
+		});
+		workspaceId = ws?.id ?? null;
+	}
+
 	try {
 		const result = await storeMemory({
 			summary,
@@ -280,6 +293,7 @@ ingest.post("/", async (c) => {
 			force: body.force,
 			replace: body.replace,
 			ttl: body.ttl,
+			workspaceId,
 		});
 
 		if (isDuplicate(result)) {

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -11,6 +11,7 @@ import {
 	countObservations,
 	getRecentSessionSummaries,
 	getSessionFilesModified,
+	getUserSetting,
 	listObservations,
 	markObservationsByIds,
 	updateSessionSummary,
@@ -20,6 +21,7 @@ import { getProvider } from "./embeddings.js";
 import { EDGE_TYPES, getGraphProviderOrNull } from "./graph.js";
 import { StoreMemoryError, isDuplicate, storeMemory } from "./ingest.js";
 import { getStorageProvider } from "./storage.js";
+import { resolveWorkspace } from "./workspace.js";
 
 const log = getLogger(["husk", "mcp"]);
 
@@ -55,6 +57,8 @@ function parseFilesModified(raw: string | null): string[] | undefined {
 
 function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 	const db = new UserScope(apiKey.user_id);
+	const autoDetect = getUserSetting(apiKey.user_id, "workspace_auto_detect") !== "false";
+	const wsOpts = { userId: apiKey.user_id, autoDetect };
 	const server = new McpServer({
 		name: "husk",
 		version: "0.1.0",
@@ -67,8 +71,12 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 				"Search memories by semantic similarity. When max_tokens is set, returns the most relevant memories that fit within the token budget — no need to guess a limit. Cost: embedding call + DB read, no LLM.",
 			inputSchema: {
 				query: z.string().describe("The search query"),
-				scope: z.enum(["session", "project", "global"]).optional().describe("Filter by scope"),
+				scope: z
+					.enum(["session", "project", "workspace", "global"])
+					.optional()
+					.describe("Filter by scope"),
 				project: z.string().optional().describe("Filter by git remote / project"),
+				workspace: z.string().optional().describe("Filter by workspace name or ID"),
 				limit: z.number().int().min(1).max(50).optional().describe("Max results (default 10)"),
 				max_tokens: z
 					.number()
@@ -98,11 +106,26 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			}
 
 			try {
+				// Resolve workspace filter
+				let workspaceId: string | undefined;
+				if (args.workspace) {
+					const ws = resolveWorkspace(args.workspace, wsOpts);
+					workspaceId = ws?.id;
+				} else if (args.scope === "workspace" && args.project) {
+					const ws = resolveWorkspace(args.project, wsOpts);
+					workspaceId = ws?.id;
+				}
+
 				// When token-budgeted, fetch generously and trim client-side
 				const fetchLimit = args.max_tokens ? 50 : (args.limit ?? 10);
 				const results = await getStorageProvider().search(
 					vector,
-					{ git_remote: args.project, scope: args.scope, user_id: apiKey.user_id },
+					{
+						git_remote: args.project,
+						scope: args.scope,
+						user_id: apiKey.user_id,
+						workspace_id: workspaceId,
+					},
 					fetchLimit,
 				);
 
@@ -152,7 +175,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			inputSchema: {
 				content: z.string().describe("The content to remember"),
 				scope: z
-					.enum(["session", "project", "global"])
+					.enum(["session", "project", "workspace", "global"])
 					.optional()
 					.describe("Memory scope (default: session)"),
 				project: z.string().optional().describe("Git remote / project identifier"),
@@ -167,12 +190,19 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					.min(0)
 					.optional()
 					.describe(
-						"TTL in seconds. 0 or omitted = scope default (session: 30d, project: 90d, global: forever).",
+						"TTL in seconds. 0 or omitted = scope default (session: 30d, project/workspace: 90d, global: forever).",
 					),
 			},
 		},
 		async (args) => {
 			try {
+				// Resolve workspace when scope is "workspace"
+				let workspaceId: string | null = null;
+				if (args.scope === "workspace" && args.project) {
+					const ws = resolveWorkspace(args.project, wsOpts);
+					workspaceId = ws?.id ?? null;
+				}
+
 				const result = await storeMemory({
 					summary: args.content,
 					apiKeyId: apiKey.id,
@@ -183,6 +213,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					force: args.force,
 					replace: args.replace,
 					ttl: args.ttl,
+					workspaceId,
 				});
 
 				if (isDuplicate(result)) {
@@ -299,7 +330,10 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 				"List all memories, optionally filtered by project and/or scope. Returns full memory objects with IDs. Use for auditing, cleanup, or bulk review. Cost: DB read only, no LLM.",
 			inputSchema: {
 				project: z.string().optional().describe("Filter by git remote / project"),
-				scope: z.enum(["session", "project", "global"]).optional().describe("Filter by scope"),
+				scope: z
+					.enum(["session", "project", "workspace", "global"])
+					.optional()
+					.describe("Filter by scope"),
 				limit: z.number().int().min(1).max(200).optional().describe("Max results (default 50)"),
 				offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)"),
 			},
@@ -891,7 +925,10 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 				"Review and clean up your memories for a project or scope. Finds duplicates, contradictions, stale info, and overly verbose memories — then consolidates them.",
 			argsSchema: {
 				project: z.string().optional().describe("Git remote / project to focus on"),
-				scope: z.enum(["session", "project", "global"]).optional().describe("Scope to review"),
+				scope: z
+					.enum(["session", "project", "workspace", "global"])
+					.optional()
+					.describe("Scope to review"),
 			},
 		},
 		(args) => {

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -115,37 +115,86 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 						getWorkspaceForUser(args.workspace, apiKey.user_id) ??
 						getWorkspaceByName(args.workspace, apiKey.user_id);
 					workspaceId = ws?.id;
-				} else if (args.scope === "workspace" && args.project) {
+				} else if (args.project) {
 					const ws = resolveWorkspace(args.project, wsOpts);
 					workspaceId = ws?.id;
 				}
 
-				// When token-budgeted, fetch generously and trim client-side
-				const fetchLimit = args.max_tokens ? 50 : (args.limit ?? 10);
-				const results = await getStorageProvider().search(
-					vector,
-					{
-						git_remote: args.project,
-						scope: args.scope,
-						user_id: apiKey.user_id,
-						workspace_id: workspaceId,
-					},
-					fetchLimit,
-				);
-
 				const now = new Date().toISOString();
-				let memories = results
-					.filter((r) => {
+				const filterExpired = (results: { score: number; payload: Record<string, unknown> }[]) =>
+					results.filter((r) => {
 						const expiresAt = r.payload?.expires_at;
 						return !expiresAt || String(expiresAt) > now;
-					})
-					.map((r) => ({
+					});
+
+				let memories: Record<string, unknown>[];
+
+				// Hierarchical search: when no scope filter and token-budgeted,
+				// walk up session → project → workspace → global filling the budget
+				if (!args.scope && args.max_tokens && args.project) {
+					const seen = new Set<string>();
+					const allResults: { score: number; payload: Record<string, unknown>; tier: number }[] =
+						[];
+
+					const tiers: { scope: string; workspace_id?: string }[] = [
+						{ scope: "session" },
+						{ scope: "project" },
+					];
+					if (workspaceId) {
+						tiers.push({ scope: "workspace", workspace_id: workspaceId });
+					}
+					tiers.push({ scope: "global" });
+
+					let tierIndex = 0;
+					for (const tier of tiers) {
+						const results = await getStorageProvider().search(
+							vector,
+							{
+								git_remote: tier.scope !== "global" ? args.project : undefined,
+								scope: tier.scope,
+								user_id: apiKey.user_id,
+								workspace_id: tier.workspace_id,
+							},
+							20,
+						);
+						for (const r of filterExpired(results)) {
+							const id = String(r.payload.memory_id ?? r.payload.id ?? "");
+							if (id && seen.has(id)) continue;
+							if (id) seen.add(id);
+							allResults.push({ ...r, tier: tierIndex });
+						}
+						tierIndex++;
+					}
+
+					// Sort by tier first (priority), then by score within tier
+					allResults.sort((a, b) => a.tier - b.tier || b.score - a.score);
+
+					memories = fitTokenBudget(
+						allResults.map((r) => ({ score: r.score, ...r.payload })),
+						args.max_tokens,
+					);
+				} else {
+					// Single-scope search (original behavior)
+					const fetchLimit = args.max_tokens ? 50 : (args.limit ?? 10);
+					const results = await getStorageProvider().search(
+						vector,
+						{
+							git_remote: args.project,
+							scope: args.scope,
+							user_id: apiKey.user_id,
+							workspace_id: args.scope === "workspace" ? workspaceId : undefined,
+						},
+						fetchLimit,
+					);
+
+					memories = filterExpired(results).map((r) => ({
 						score: r.score,
 						...(r.payload ?? {}),
 					}));
 
-				if (args.max_tokens) {
-					memories = fitTokenBudget(memories, args.max_tokens);
+					if (args.max_tokens) {
+						memories = fitTokenBudget(memories, args.max_tokens);
+					}
 				}
 
 				return {

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -12,6 +12,8 @@ import {
 	getRecentSessionSummaries,
 	getSessionFilesModified,
 	getUserSetting,
+	getWorkspaceByName,
+	getWorkspaceForUser,
 	listObservations,
 	markObservationsByIds,
 	updateSessionSummary,
@@ -109,7 +111,9 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 				// Resolve workspace filter
 				let workspaceId: string | undefined;
 				if (args.workspace) {
-					const ws = resolveWorkspace(args.workspace, wsOpts);
+					const ws =
+						getWorkspaceForUser(args.workspace, apiKey.user_id) ??
+						getWorkspaceByName(args.workspace, apiKey.user_id);
 					workspaceId = ws?.id;
 				} else if (args.scope === "workspace" && args.project) {
 					const ws = resolveWorkspace(args.project, wsOpts);

--- a/server/src/sessions.ts
+++ b/server/src/sessions.ts
@@ -10,10 +10,13 @@ import {
 	getConfig,
 	getConfigWithEnv,
 	getRecentSessionSummaries,
+	getUserSetting,
+	listWorkspaceProjects,
 } from "./db.js";
 import type { AppEnv } from "./env.js";
 import { bus } from "./events.js";
 import { applyPrivacyFilters } from "./privacy.js";
+import { resolveWorkspace } from "./workspace.js";
 
 const log = getLogger(["husk", "sessions"]);
 
@@ -130,6 +133,36 @@ sessions.post("/session-start", async (c) => {
 		project,
 		limit: contextCount,
 	});
+
+	// Include sessions from sibling projects in the same workspace
+	const autoDetect = getUserSetting(apiKey.user_id, "workspace_auto_detect") !== "false";
+	const workspace = project
+		? resolveWorkspace(project, { userId: apiKey.user_id, autoDetect })
+		: undefined;
+
+	const siblingSessionIds = new Set(recentSessions.map((s) => s.id));
+	if (workspace) {
+		const siblingProjects = listWorkspaceProjects(workspace.id).filter((p) => p !== project);
+		for (const siblingProject of siblingProjects) {
+			const siblingSessions = getRecentSessionSummaries({
+				userId: apiKey.user_id,
+				project: siblingProject,
+				limit: 3,
+			});
+			for (const s of siblingSessions) {
+				if (!siblingSessionIds.has(s.id)) {
+					recentSessions.push(s);
+					siblingSessionIds.add(s.id);
+				}
+			}
+		}
+		// Re-sort by date after merging
+		recentSessions.sort(
+			(a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
+		);
+		// Trim to context count
+		recentSessions.splice(contextCount);
+	}
 
 	if (recentSessions.length === 0) {
 		return c.json({}, 200);

--- a/server/src/storage-qdrant.ts
+++ b/server/src/storage-qdrant.ts
@@ -52,6 +52,9 @@ export class QdrantStorageProvider implements StorageProvider {
 		if (filter?.scope) {
 			must.push({ key: "scope", match: { value: filter.scope } });
 		}
+		if (filter?.workspace_id) {
+			must.push({ key: "workspace_id", match: { value: filter.workspace_id } });
+		}
 
 		const results = await client.search(COLLECTION_NAME, {
 			vector,

--- a/server/src/storage-sqlite-vec.ts
+++ b/server/src/storage-sqlite-vec.ts
@@ -198,6 +198,7 @@ export class SqliteVecStorageProvider implements StorageProvider {
 				if (filter.user_id && entry.payload.user_id !== filter.user_id) continue;
 				if (filter.git_remote && entry.payload.git_remote !== filter.git_remote) continue;
 				if (filter.scope && entry.payload.scope !== filter.scope) continue;
+				if (filter.workspace_id && entry.payload.workspace_id !== filter.workspace_id) continue;
 			}
 
 			results.push({

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -19,6 +19,7 @@ export interface MemoryFilter {
 	git_remote?: string;
 	scope?: string;
 	user_id?: string;
+	workspace_id?: string;
 }
 
 export interface VectorSearchResult {

--- a/server/src/workspace-api.test.ts
+++ b/server/src/workspace-api.test.ts
@@ -66,6 +66,46 @@ describe("workspace API", () => {
 		expect(res.status).toBe(400);
 	});
 
+	test("allows unicode workspace names", async () => {
+		for (const name of ["ÆØÅ-projekt", "café", "über-team", "日本語"]) {
+			const res = await authed("/api/admin/workspaces", adminToken, {
+				method: "POST",
+				body: JSON.stringify({ name }),
+			});
+			expect(res.status).toBe(201);
+		}
+	});
+
+	test("allows hyphens, underscores, dots in names", async () => {
+		for (const name of ["my-workspace", "my_workspace", "my.workspace", "a1-b2_c3.d4"]) {
+			const res = await authed("/api/admin/workspaces", adminToken, {
+				method: "POST",
+				body: JSON.stringify({ name }),
+			});
+			expect(res.status).toBe(201);
+		}
+	});
+
+	test("rejects names starting with special characters", async () => {
+		for (const name of ["-starts-with-dash", ".starts-with-dot", "_starts-with-underscore"]) {
+			const res = await authed("/api/admin/workspaces", adminToken, {
+				method: "POST",
+				body: JSON.stringify({ name }),
+			});
+			expect(res.status).toBe(400);
+		}
+	});
+
+	test("rejects empty and whitespace-only names", async () => {
+		for (const name of ["", "   "]) {
+			const res = await authed("/api/admin/workspaces", adminToken, {
+				method: "POST",
+				body: JSON.stringify({ name }),
+			});
+			expect(res.status).toBe(400);
+		}
+	});
+
 	test("rejects duplicate workspace names for same user", async () => {
 		await authed("/api/admin/workspaces", adminToken, {
 			method: "POST",

--- a/server/src/workspace-api.test.ts
+++ b/server/src/workspace-api.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { setProvider } from "./embeddings.js";
+import type { StorageProvider } from "./storage.js";
+import { setStorageProvider } from "./storage.js";
+import { createRegularUser, createTestApp, getToken, setupAdmin } from "./test-helpers.js";
+
+const mockProvider: EmbeddingProvider = {
+	name: "mock",
+	dimensions: 768,
+	embed: () => Promise.resolve(new Array(768).fill(0.1)),
+};
+
+const mockStorage: StorageProvider = {
+	name: "mock",
+	init: () => Promise.resolve(),
+	upsert: () => Promise.resolve(),
+	search: () => Promise.resolve([]),
+	delete: () => Promise.resolve(),
+	healthy: () => Promise.resolve(true),
+};
+
+let app: ReturnType<typeof createTestApp>;
+let adminToken: string;
+
+async function authed(path: string, token: string, init?: RequestInit) {
+	return app.request(path, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+			...(init?.headers ?? {}),
+		},
+	});
+}
+
+describe("workspace API", () => {
+	beforeEach(async () => {
+		app = createTestApp();
+		setProvider(mockProvider);
+		setStorageProvider(mockStorage);
+		await setupAdmin(app);
+		adminToken = await getToken(app);
+	});
+
+	test("create and list workspaces", async () => {
+		const create = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "my-workspace" }),
+		});
+		expect(create.status).toBe(201);
+		const { id } = (await create.json()) as { id: string };
+
+		const list = await authed("/api/admin/workspaces", adminToken);
+		const body = (await list.json()) as { workspaces: { id: string; name: string }[] };
+		expect(body.workspaces).toHaveLength(1);
+		expect(body.workspaces[0]?.name).toBe("my-workspace");
+		expect(body.workspaces[0]?.id).toBe(id);
+	});
+
+	test("rejects invalid workspace names", async () => {
+		const res = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "no spaces allowed" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	test("rejects duplicate workspace names for same user", async () => {
+		await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "dupe" }),
+		});
+		const res = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "dupe" }),
+		});
+		expect(res.status).toBe(409);
+	});
+
+	test("different users can have same workspace name", async () => {
+		await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "shared-name" }),
+		});
+
+		const user = await createRegularUser(app, adminToken);
+		const res = await authed("/api/admin/workspaces", user.token, {
+			method: "POST",
+			body: JSON.stringify({ name: "shared-name" }),
+		});
+		expect(res.status).toBe(201);
+	});
+
+	test("users can only see their own workspaces", async () => {
+		await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "admin-ws" }),
+		});
+
+		const user = await createRegularUser(app, adminToken);
+		await authed("/api/admin/workspaces", user.token, {
+			method: "POST",
+			body: JSON.stringify({ name: "user-ws" }),
+		});
+
+		const adminList = await authed("/api/admin/workspaces", adminToken);
+		const adminBody = (await adminList.json()) as {
+			workspaces: { name: string }[];
+		};
+		// Admin sees all
+		expect(adminBody.workspaces).toHaveLength(2);
+
+		const userList = await authed("/api/admin/workspaces", user.token);
+		const userBody = (await userList.json()) as {
+			workspaces: { name: string }[];
+		};
+		// User sees only their own
+		expect(userBody.workspaces).toHaveLength(1);
+		expect(userBody.workspaces[0]?.name).toBe("user-ws");
+	});
+
+	test("user cannot delete another user's workspace", async () => {
+		const create = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "admin-ws" }),
+		});
+		const { id } = (await create.json()) as { id: string };
+
+		const user = await createRegularUser(app, adminToken);
+		const del = await authed(`/api/admin/workspaces/${id}`, user.token, {
+			method: "DELETE",
+		});
+		expect(del.status).toBe(404);
+	});
+
+	test("user cannot update another user's workspace", async () => {
+		const create = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "admin-ws" }),
+		});
+		const { id } = (await create.json()) as { id: string };
+
+		const user = await createRegularUser(app, adminToken);
+		const put = await authed(`/api/admin/workspaces/${id}`, user.token, {
+			method: "PUT",
+			body: JSON.stringify({ name: "stolen" }),
+		});
+		expect(put.status).toBe(404);
+	});
+
+	test("assign and remove projects", async () => {
+		const create = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "my-ws" }),
+		});
+		const { id } = (await create.json()) as { id: string };
+
+		const assign = await authed(`/api/admin/workspaces/${id}/projects`, adminToken, {
+			method: "POST",
+			body: JSON.stringify({ git_remote: "github.com/org/repo" }),
+		});
+		expect(assign.status).toBe(201);
+
+		const detail = await authed(`/api/admin/workspaces/${id}`, adminToken);
+		const body = (await detail.json()) as { projects: string[] };
+		expect(body.projects).toContain("github.com/org/repo");
+
+		const remove = await authed(
+			`/api/admin/workspaces/${id}/projects/${encodeURIComponent("github.com/org/repo")}`,
+			adminToken,
+			{ method: "DELETE" },
+		);
+		expect(remove.status).toBe(200);
+	});
+
+	test("cannot steal project from another user's workspace", async () => {
+		const adminCreate = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "admin-ws" }),
+		});
+		const { id: adminWsId } = (await adminCreate.json()) as { id: string };
+		await authed(`/api/admin/workspaces/${adminWsId}/projects`, adminToken, {
+			method: "POST",
+			body: JSON.stringify({ git_remote: "github.com/org/repo" }),
+		});
+
+		const user = await createRegularUser(app, adminToken);
+		const userCreate = await authed("/api/admin/workspaces", user.token, {
+			method: "POST",
+			body: JSON.stringify({ name: "user-ws" }),
+		});
+		const { id: userWsId } = (await userCreate.json()) as { id: string };
+
+		const steal = await authed(`/api/admin/workspaces/${userWsId}/projects`, user.token, {
+			method: "POST",
+			body: JSON.stringify({ git_remote: "github.com/org/repo" }),
+		});
+		expect(steal.status).toBe(409);
+	});
+
+	test("cannot remove project from another user's workspace", async () => {
+		const adminCreate = await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "admin-ws" }),
+		});
+		const { id: adminWsId } = (await adminCreate.json()) as { id: string };
+		await authed(`/api/admin/workspaces/${adminWsId}/projects`, adminToken, {
+			method: "POST",
+			body: JSON.stringify({ git_remote: "github.com/org/repo" }),
+		});
+
+		const user = await createRegularUser(app, adminToken);
+		const userCreate = await authed("/api/admin/workspaces", user.token, {
+			method: "POST",
+			body: JSON.stringify({ name: "user-ws" }),
+		});
+		const { id: userWsId } = (await userCreate.json()) as { id: string };
+
+		// Try to remove admin's project through user's workspace
+		const remove = await authed(
+			`/api/admin/workspaces/${userWsId}/projects/${encodeURIComponent("github.com/org/repo")}`,
+			user.token,
+			{ method: "DELETE" },
+		);
+		expect(remove.status).toBe(404);
+	});
+
+	test("workspace count in stats", async () => {
+		await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "ws-1" }),
+		});
+		await authed("/api/admin/workspaces", adminToken, {
+			method: "POST",
+			body: JSON.stringify({ name: "ws-2" }),
+		});
+
+		const stats = await authed("/api/admin/stats", adminToken);
+		const body = (await stats.json()) as { workspaces: number };
+		expect(body.workspaces).toBe(2);
+	});
+});

--- a/server/src/workspace.test.ts
+++ b/server/src/workspace.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { inferWorkspaceFromRemote } from "./workspace.js";
+
+describe("inferWorkspaceFromRemote", () => {
+	test("extracts org from GitHub HTTPS URL", () => {
+		expect(inferWorkspaceFromRemote("https://github.com/Saturate/HUSK")).toBe("Saturate");
+	});
+
+	test("extracts org from GitHub HTTPS URL with .git suffix", () => {
+		expect(inferWorkspaceFromRemote("https://github.com/my-org/my-repo.git")).toBe("my-org");
+	});
+
+	test("extracts org from GitHub SSH URL", () => {
+		expect(inferWorkspaceFromRemote("git@github.com:Saturate/HUSK.git")).toBe("Saturate");
+	});
+
+	test("extracts org from GitLab HTTPS URL", () => {
+		expect(inferWorkspaceFromRemote("https://gitlab.com/my-group/my-project")).toBe("my-group");
+	});
+
+	test("extracts org from GitLab SSH URL", () => {
+		expect(inferWorkspaceFromRemote("git@gitlab.com:my-group/my-project.git")).toBe("my-group");
+	});
+
+	test("extracts org from Azure DevOps HTTPS URL", () => {
+		expect(inferWorkspaceFromRemote("https://dev.azure.com/my-org/my-project/_git/my-repo")).toBe(
+			"my-org",
+		);
+	});
+
+	test("extracts org from Bitbucket SSH URL", () => {
+		expect(inferWorkspaceFromRemote("git@bitbucket.org:my-team/my-repo.git")).toBe("my-team");
+	});
+
+	test("returns null for malformed URLs", () => {
+		expect(inferWorkspaceFromRemote("not-a-url")).toBeNull();
+	});
+
+	test("returns null for empty string", () => {
+		expect(inferWorkspaceFromRemote("")).toBeNull();
+	});
+
+	test("returns null for URL with single path segment", () => {
+		expect(inferWorkspaceFromRemote("https://github.com/solo")).toBeNull();
+	});
+});

--- a/server/src/workspace.ts
+++ b/server/src/workspace.ts
@@ -1,0 +1,50 @@
+import { type WorkspaceRow, getWorkspaceByName, getWorkspaceForProject } from "./db.js";
+
+/**
+ * Parse an org/group name from a git remote URL.
+ * Handles HTTPS and SSH formats for GitHub, GitLab, Bitbucket, Azure DevOps.
+ */
+export function inferWorkspaceFromRemote(gitRemote: string): string | null {
+	// SSH: git@github.com:org/repo.git
+	const sshMatch = gitRemote.match(/^git@[^:]+:([^/]+)\//);
+	if (sshMatch?.[1]) return sshMatch[1];
+
+	// HTTPS: https://github.com/org/repo or https://dev.azure.com/org/project
+	try {
+		const url = new URL(gitRemote);
+		const parts = url.pathname.split("/").filter(Boolean);
+		if (parts.length >= 2 && parts[0]) return parts[0];
+	} catch {
+		// Not a valid URL
+	}
+
+	return null;
+}
+
+/**
+ * Resolve a workspace for a git remote, scoped to a specific user:
+ * 1. Check explicit mapping in workspace_projects table (owned by userId)
+ * 2. If auto-detect enabled, infer org name and look up existing workspace by name (owned by userId)
+ *
+ * Only resolves to existing workspaces owned by the user — never auto-creates.
+ */
+export function resolveWorkspace(
+	gitRemote: string | null | undefined,
+	opts?: { autoDetect?: boolean; userId?: string },
+): WorkspaceRow | undefined {
+	if (!gitRemote) return undefined;
+
+	// Explicit mapping takes priority
+	const explicit = getWorkspaceForProject(gitRemote, opts?.userId);
+	if (explicit) return explicit;
+
+	// Auto-detect: infer org name, match against existing workspaces
+	if (opts?.autoDetect !== false) {
+		const inferred = inferWorkspaceFromRemote(gitRemote);
+		if (inferred) {
+			return getWorkspaceByName(inferred, opts?.userId);
+		}
+	}
+
+	return undefined;
+}

--- a/server/ui/src/api.ts
+++ b/server/ui/src/api.ts
@@ -128,6 +128,23 @@ export interface StatsResponse {
 	keys: { total: number; active: number };
 	projects: number;
 	sessions: { total: number; active: number };
+	workspaces: number;
+}
+
+export interface Workspace {
+	id: string;
+	name: string;
+	created_by: string;
+	created_at: string;
+	project_count: number;
+}
+
+export interface WorkspaceDetail extends Workspace {
+	projects: string[];
+}
+
+export interface WorkspacesResponse {
+	workspaces: Workspace[];
 }
 
 export interface FiltersResponse {
@@ -409,5 +426,53 @@ export const api = {
 		if (opts?.limit) params.set("limit", String(opts.limit));
 		const qs = params.toString();
 		return request<GraphResponse>(`/api/graph${qs ? `?${qs}` : ""}`);
+	},
+
+	// --- Workspaces ---
+
+	listWorkspaces() {
+		return request<WorkspacesResponse>("/api/admin/workspaces");
+	},
+
+	createWorkspace(name: string) {
+		return request<{ id: string; name: string }>("/api/admin/workspaces", {
+			method: "POST",
+			body: JSON.stringify({ name }),
+		});
+	},
+
+	getWorkspace(id: string) {
+		return request<WorkspaceDetail>(`/api/admin/workspaces/${encodeURIComponent(id)}`);
+	},
+
+	updateWorkspace(id: string, name: string) {
+		return request<{ ok: true }>(`/api/admin/workspaces/${encodeURIComponent(id)}`, {
+			method: "PUT",
+			body: JSON.stringify({ name }),
+		});
+	},
+
+	deleteWorkspace(id: string) {
+		return request<{ id: string; deleted: true }>(
+			`/api/admin/workspaces/${encodeURIComponent(id)}`,
+			{ method: "DELETE" },
+		);
+	},
+
+	assignProjectToWorkspace(workspaceId: string, gitRemote: string) {
+		return request<{ workspace_id: string; git_remote: string }>(
+			`/api/admin/workspaces/${encodeURIComponent(workspaceId)}/projects`,
+			{
+				method: "POST",
+				body: JSON.stringify({ git_remote: gitRemote }),
+			},
+		);
+	},
+
+	removeProjectFromWorkspace(workspaceId: string, gitRemote: string) {
+		return request<{ git_remote: string; deleted: true }>(
+			`/api/admin/workspaces/${encodeURIComponent(workspaceId)}/projects/${encodeURIComponent(gitRemote)}`,
+			{ method: "DELETE" },
+		);
 	},
 };

--- a/server/ui/src/api.ts
+++ b/server/ui/src/api.ts
@@ -116,6 +116,7 @@ export interface Memory {
 	summary: string;
 	metadata: string | null;
 	created_at: string;
+	workspace_id: string | null;
 }
 
 export interface MemoriesResponse {
@@ -474,5 +475,16 @@ export const api = {
 			`/api/admin/workspaces/${encodeURIComponent(workspaceId)}/projects/${encodeURIComponent(gitRemote)}`,
 			{ method: "DELETE" },
 		);
+	},
+
+	getWorkspaceAutoDetect() {
+		return request<{ enabled: boolean }>("/api/admin/user-settings/workspace-auto-detect");
+	},
+
+	setWorkspaceAutoDetect(enabled: boolean) {
+		return request<{ ok: true }>("/api/admin/user-settings/workspace-auto-detect", {
+			method: "PUT",
+			body: JSON.stringify({ enabled }),
+		});
 	},
 };

--- a/server/ui/src/components/layout.tsx
+++ b/server/ui/src/components/layout.tsx
@@ -41,6 +41,7 @@ const NAV_ITEMS: NavItem[] = [
 	{ to: "/sessions", label: "Sessions" },
 	{ to: "/graph", label: "Graph" },
 	{ to: "/timeline", label: "Timeline" },
+	{ to: "/workspaces", label: "Workspaces" },
 	{ to: "/users", label: "Users", adminOnly: true },
 	{ to: "/settings", label: "Settings" },
 ];

--- a/server/ui/src/pages/workspaces.tsx
+++ b/server/ui/src/pages/workspaces.tsx
@@ -1,0 +1,303 @@
+import { api } from "@/api";
+import { AppLayout } from "@/components/layout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { relativeTime } from "@/lib/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+export function WorkspacesPage() {
+	const queryClient = useQueryClient();
+	const [expandedId, setExpandedId] = useState<string | null>(null);
+	const [newName, setNewName] = useState("");
+	const [assignRemote, setAssignRemote] = useState("");
+	const [assignWorkspaceId, setAssignWorkspaceId] = useState<string | null>(null);
+
+	const workspacesQuery = useQuery({
+		queryKey: ["workspaces"],
+		queryFn: () => api.listWorkspaces(),
+	});
+
+	const filtersQuery = useQuery({
+		queryKey: ["filters"],
+		queryFn: () => api.getFilters(),
+	});
+
+	const detailQuery = useQuery({
+		queryKey: ["workspaces", "detail", expandedId],
+		queryFn: () => {
+			if (!expandedId) throw new Error("unreachable");
+			return api.getWorkspace(expandedId);
+		},
+		enabled: expandedId !== null,
+	});
+
+	const createMutation = useMutation({
+		mutationFn: (name: string) => api.createWorkspace(name),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+			setNewName("");
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: (id: string) => api.deleteWorkspace(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+			queryClient.invalidateQueries({ queryKey: ["stats"] });
+			setExpandedId(null);
+		},
+	});
+
+	const assignMutation = useMutation({
+		mutationFn: ({ workspaceId, gitRemote }: { workspaceId: string; gitRemote: string }) =>
+			api.assignProjectToWorkspace(workspaceId, gitRemote),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+			setAssignRemote("");
+			setAssignWorkspaceId(null);
+		},
+	});
+
+	const removeMutation = useMutation({
+		mutationFn: ({ workspaceId, gitRemote }: { workspaceId: string; gitRemote: string }) =>
+			api.removeProjectFromWorkspace(workspaceId, gitRemote),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspaces"] });
+		},
+	});
+
+	const workspaces = workspacesQuery.data?.workspaces ?? [];
+	const projects = filtersQuery.data?.projects ?? [];
+
+	return (
+		<AppLayout>
+			<div className="mb-6 flex items-center justify-between">
+				<h2 className="text-2xl font-semibold">Workspaces</h2>
+				<Dialog>
+					<DialogTrigger asChild>
+						<Button size="sm">
+							<Plus className="mr-1 h-4 w-4" /> New Workspace
+						</Button>
+					</DialogTrigger>
+					<DialogContent>
+						<DialogHeader>
+							<DialogTitle>Create Workspace</DialogTitle>
+							<DialogDescription>
+								Group related projects so memories can be shared across them.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-2">
+							<Label htmlFor="ws-name">Name</Label>
+							<Input
+								id="ws-name"
+								placeholder="e.g. client-a"
+								value={newName}
+								onChange={(e) => setNewName(e.target.value)}
+							/>
+						</div>
+						<DialogFooter>
+							<DialogClose asChild>
+								<Button variant="ghost">Cancel</Button>
+							</DialogClose>
+							<DialogClose asChild>
+								<Button
+									disabled={!newName.trim() || createMutation.isPending}
+									onClick={() => createMutation.mutate(newName.trim())}
+								>
+									Create
+								</Button>
+							</DialogClose>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
+			</div>
+
+			{workspacesQuery.isLoading ? (
+				<p className="text-sm text-muted-foreground">Loading...</p>
+			) : workspaces.length === 0 ? (
+				<div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12">
+					<p className="text-sm text-muted-foreground">
+						No workspaces yet. Create one to group related projects.
+					</p>
+				</div>
+			) : (
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-[30px]" />
+							<TableHead>Name</TableHead>
+							<TableHead>Projects</TableHead>
+							<TableHead>Created</TableHead>
+							<TableHead className="w-[50px]" />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{workspaces.map((ws) => (
+							<>
+								<TableRow key={ws.id}>
+									<TableCell>
+										<Button
+											size="icon"
+											variant="ghost"
+											className="h-6 w-6"
+											onClick={() => setExpandedId(expandedId === ws.id ? null : ws.id)}
+										>
+											{expandedId === ws.id ? (
+												<ChevronUp className="h-4 w-4" />
+											) : (
+												<ChevronDown className="h-4 w-4" />
+											)}
+										</Button>
+									</TableCell>
+									<TableCell className="font-medium">{ws.name}</TableCell>
+									<TableCell>
+										<Badge variant="secondary">{ws.project_count}</Badge>
+									</TableCell>
+									<TableCell className="text-sm text-muted-foreground">
+										{relativeTime(ws.created_at)}
+									</TableCell>
+									<TableCell>
+										<Button
+											size="icon"
+											variant="ghost"
+											aria-label="Delete workspace"
+											disabled={deleteMutation.isPending}
+											onClick={() => deleteMutation.mutate(ws.id)}
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									</TableCell>
+								</TableRow>
+								{expandedId === ws.id && (
+									<TableRow key={`${ws.id}-detail`}>
+										<TableCell colSpan={5} className="bg-muted/50 p-4">
+											{detailQuery.isLoading ? (
+												<p className="text-sm text-muted-foreground">Loading...</p>
+											) : (
+												<div className="space-y-3">
+													<div className="flex items-center justify-between">
+														<p className="text-xs font-medium uppercase text-muted-foreground">
+															Assigned Projects
+														</p>
+														<Dialog
+															open={assignWorkspaceId === ws.id}
+															onOpenChange={(open) => setAssignWorkspaceId(open ? ws.id : null)}
+														>
+															<DialogTrigger asChild>
+																<Button size="sm" variant="outline">
+																	<Plus className="mr-1 h-3 w-3" /> Assign Project
+																</Button>
+															</DialogTrigger>
+															<DialogContent>
+																<DialogHeader>
+																	<DialogTitle>Assign Project</DialogTitle>
+																	<DialogDescription>
+																		Add a project to "{ws.name}".
+																	</DialogDescription>
+																</DialogHeader>
+																<div className="space-y-2">
+																	<Label>Project</Label>
+																	<Select value={assignRemote} onValueChange={setAssignRemote}>
+																		<SelectTrigger>
+																			<SelectValue placeholder="Select a project" />
+																		</SelectTrigger>
+																		<SelectContent>
+																			{projects.map((p) => (
+																				<SelectItem key={p} value={p}>
+																					{p}
+																				</SelectItem>
+																			))}
+																		</SelectContent>
+																	</Select>
+																</div>
+																<DialogFooter>
+																	<DialogClose asChild>
+																		<Button variant="ghost">Cancel</Button>
+																	</DialogClose>
+																	<DialogClose asChild>
+																		<Button
+																			disabled={!assignRemote || assignMutation.isPending}
+																			onClick={() =>
+																				assignMutation.mutate({
+																					workspaceId: ws.id,
+																					gitRemote: assignRemote,
+																				})
+																			}
+																		>
+																			Assign
+																		</Button>
+																	</DialogClose>
+																</DialogFooter>
+															</DialogContent>
+														</Dialog>
+													</div>
+													{(detailQuery.data?.projects ?? []).length === 0 ? (
+														<p className="text-sm text-muted-foreground">No projects assigned.</p>
+													) : (
+														<div className="space-y-1">
+															{detailQuery.data?.projects.map((remote) => (
+																<div
+																	key={remote}
+																	className="flex items-center justify-between rounded border bg-background px-3 py-2 text-sm"
+																>
+																	<span className="truncate text-muted-foreground">{remote}</span>
+																	<Button
+																		size="icon"
+																		variant="ghost"
+																		className="h-6 w-6 shrink-0"
+																		disabled={removeMutation.isPending}
+																		onClick={() =>
+																			removeMutation.mutate({
+																				workspaceId: ws.id,
+																				gitRemote: remote,
+																			})
+																		}
+																	>
+																		<Trash2 className="h-3 w-3" />
+																	</Button>
+																</div>
+															))}
+														</div>
+													)}
+												</div>
+											)}
+										</TableCell>
+									</TableRow>
+								)}
+							</>
+						))}
+					</TableBody>
+				</Table>
+			)}
+		</AppLayout>
+	);
+}

--- a/server/ui/src/pages/workspaces.tsx
+++ b/server/ui/src/pages/workspaces.tsx
@@ -95,8 +95,21 @@ export function WorkspacesPage() {
 		},
 	});
 
+	const autoDetectQuery = useQuery({
+		queryKey: ["workspace-auto-detect"],
+		queryFn: () => api.getWorkspaceAutoDetect(),
+	});
+
+	const autoDetectMutation = useMutation({
+		mutationFn: (enabled: boolean) => api.setWorkspaceAutoDetect(enabled),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["workspace-auto-detect"] });
+		},
+	});
+
 	const workspaces = workspacesQuery.data?.workspaces ?? [];
 	const projects = filtersQuery.data?.projects ?? [];
+	const autoDetectEnabled = autoDetectQuery.data?.enabled ?? true;
 
 	return (
 		<AppLayout>
@@ -139,6 +152,23 @@ export function WorkspacesPage() {
 						</DialogFooter>
 					</DialogContent>
 				</Dialog>
+			</div>
+
+			<div className="mb-6 flex items-center justify-between rounded-lg border bg-muted/50 px-4 py-3">
+				<div>
+					<p className="text-sm font-medium">Auto-detect workspaces</p>
+					<p className="text-xs text-muted-foreground">
+						Infer workspace from git remote org name (e.g. github.com/my-org/* → "my-org")
+					</p>
+				</div>
+				<Button
+					size="sm"
+					variant={autoDetectEnabled ? "default" : "outline"}
+					disabled={autoDetectMutation.isPending}
+					onClick={() => autoDetectMutation.mutate(!autoDetectEnabled)}
+				>
+					{autoDetectEnabled ? "Enabled" : "Disabled"}
+				</Button>
 			</div>
 
 			{workspacesQuery.isLoading ? (

--- a/server/ui/src/router.tsx
+++ b/server/ui/src/router.tsx
@@ -12,6 +12,7 @@ import { SettingsPage } from "@/pages/settings";
 import { SetupPage } from "@/pages/setup";
 import { TimelinePage } from "@/pages/timeline";
 import { UsersPage } from "@/pages/users";
+import { WorkspacesPage } from "@/pages/workspaces";
 import { ThemeProvider } from "@/theme-context";
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
@@ -53,6 +54,7 @@ export function App() {
 								<Route path="/sessions" element={<SessionsPage />} />
 								<Route path="/graph" element={<GraphPage />} />
 								<Route path="/timeline" element={<TimelinePage />} />
+								<Route path="/workspaces" element={<WorkspacesPage />} />
 								<Route path="/users" element={<UsersPage />} />
 								<Route path="/settings" element={<SettingsPage />} />
 							</Route>

--- a/website/content/docs/concepts/memory-scopes.mdx
+++ b/website/content/docs/concepts/memory-scopes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Memory Scopes
-description: Session, project, and global scopes — how memories are organized and expire.
+description: Session, project, workspace, and global scopes — how memories are organized and expire.
 ---
 
 ## Scopes
@@ -11,6 +11,7 @@ Every memory has a scope that determines its visibility and default lifetime:
 |---|---|---|
 | `session` | Single coding session — what you just did, decisions made, blockers hit | 30 days |
 | `project` | Per-repo knowledge — API quirks, architecture decisions, team conventions | 90 days |
+| `workspace` | Shared across related repos — org-wide standards, client-specific patterns | 90 days |
 | `global` | Cross-project patterns — personal preferences, tool configs, workflow habits | Forever |
 
 ## Project keying
@@ -18,6 +19,15 @@ Every memory has a scope that determines its visibility and default lifetime:
 Projects are identified by **git remote URL**. This means the same project is recognized regardless of where the repo is checked out — different machines, different paths, same project.
 
 When storing a memory with `scope: "project"`, the `project` field should be the git remote (e.g. `git@github.com:Saturate/HUSK.git`). The Claude Code plugin handles this automatically.
+
+## Workspaces
+
+Workspaces group related projects so memories can be shared across repos. For example, a "client-a" workspace might contain all repos for that client — memories scoped to `workspace` are visible from any project in the group.
+
+- Create and manage workspaces in the admin UI under **Workspaces**
+- Assign projects (git remotes) to workspaces
+- Auto-detection can infer the workspace from the git remote's org name (e.g. `github.com/my-org/*` → workspace "my-org"), toggleable per user
+- Search walks up the hierarchy: session → project → workspace → global
 
 ## TTL and expiry
 

--- a/website/content/docs/configuration.mdx
+++ b/website/content/docs/configuration.mdx
@@ -116,6 +116,7 @@ Default TTLs per scope, configurable via environment variables or admin config:
 |---|---|---|---|
 | `HUSK_TTL_DEFAULT_SESSION` | `ttl_default_session` | `2592000` (30 days) | Session memory TTL |
 | `HUSK_TTL_DEFAULT_PROJECT` | `ttl_default_project` | `7776000` (90 days) | Project memory TTL |
+| `HUSK_TTL_DEFAULT_WORKSPACE` | `ttl_default_workspace` | `7776000` (90 days) | Workspace memory TTL |
 | `HUSK_TTL_DEFAULT_GLOBAL` | `ttl_default_global` | _(none)_ | Global memory TTL (forever by default) |
 | `HUSK_TTL_MAX` | `ttl_max` | _(none)_ | Hard ceiling for all TTLs |
 

--- a/website/content/docs/mcp-tools/memory-tools.mdx
+++ b/website/content/docs/mcp-tools/memory-tools.mdx
@@ -14,8 +14,9 @@ Search memories by semantic similarity. Returns the most relevant memories for a
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `query` | string | Yes | The search query |
-| `scope` | `"session"` \| `"project"` \| `"global"` | No | Filter by scope |
+| `scope` | `"session"` \| `"project"` \| `"workspace"` \| `"global"` | No | Filter by scope |
 | `project` | string | No | Filter by git remote / project |
+| `workspace` | string | No | Filter by workspace name or ID |
 | `limit` | integer (1–50) | No | Max results. Default: 10 |
 | `max_tokens` | integer (1–100,000) | No | Token budget — returns memories until budget is exhausted. Overrides `limit`. |
 
@@ -48,7 +49,7 @@ Store a new memory. Checks for duplicates automatically — if a similar memory 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `content` | string | Yes | The content to remember |
-| `scope` | `"session"` \| `"project"` \| `"global"` | No | Memory scope. Default: `"session"` |
+| `scope` | `"session"` \| `"project"` \| `"workspace"` \| `"global"` | No | Memory scope. Default: `"session"` |
 | `project` | string | No | Git remote / project identifier |
 | `force` | boolean | No | Skip duplicate check and store anyway |
 | `replace` | string | No | ID of an existing memory to overwrite |
@@ -66,6 +67,7 @@ Use `force: true` to skip this check, or `replace: "id"` to explicitly overwrite
 |---|---|
 | `session` | 30 days (2,592,000s) |
 | `project` | 90 days (7,776,000s) |
+| `workspace` | 90 days (7,776,000s) |
 | `global` | Forever |
 
 ### Example
@@ -113,7 +115,7 @@ List all memories with optional filters. Returns full memory objects including I
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `project` | string | No | Filter by git remote / project |
-| `scope` | `"session"` \| `"project"` \| `"global"` | No | Filter by scope |
+| `scope` | `"session"` \| `"project"` \| `"workspace"` \| `"global"` | No | Filter by scope |
 | `limit` | integer (1–200) | No | Max results. Default: 50 |
 | `offset` | integer | No | Pagination offset. Default: 0 |
 


### PR DESCRIPTION
## Summary

- Adds a **workspace** scope layer between project and global — groups related repos so memories are shared across them
- Scope hierarchy: `session → project → workspace → global`
- Hierarchical search fills token budget walking up the scope chain automatically
- Session-start hook injects context from sibling projects in the same workspace
- Per-user ownership on all workspace operations, auto-detect from git remote org name
- Admin UI page for workspace CRUD, project assignment, and auto-detect toggle

## Security

- All workspace operations scoped by `created_by` — users only see/modify their own
- Admins get read-all visibility, mutations are owner-only
- Project assignment prevents stealing from other users' workspaces (409)
- Workspace name uniqueness is per-user, not global
- Name validation: `^[\p{L}\p{N}][\p{L}\p{N}._-]{0,62}$` (unicode-safe)
- User deletion cascades workspaces, project assignments, and user settings
- Workspace deletion re-scopes memories to "project" instead of orphaning them