### PR TITLE
feat: auto-classify memory type on store

### DIFF
--- a/server/src/admin.test.ts
+++ b/server/src/admin.test.ts
@@ -203,8 +203,8 @@ describe("admin API", () => {
 			headers: { Authorization: `Bearer ${token}` },
 		});
 		expect(res.status).toBe(200);
-		const body = (await res.json()) as { id: string; deleted: boolean };
-		expect(body.deleted).toBe(true);
+		const body = (await res.json()) as { id: string; soft_deleted: boolean };
+		expect(body.soft_deleted).toBe(true);
 	});
 
 	test("DELETE /memories/:id returns 404 for missing", async () => {

--- a/server/src/admin.ts
+++ b/server/src/admin.ts
@@ -23,6 +23,8 @@ import {
 	getWorkspaceForUser,
 	listApiKeys,
 	listDistinctGitRemotes,
+	listDistinctMemoryTypes,
+	listDistinctPaths,
 	listDistinctScopes,
 	listMemories,
 	listObservations,
@@ -30,8 +32,10 @@ import {
 	listWorkspaceProjects,
 	listWorkspaces,
 	removeProjectFromWorkspace,
+	restoreMemory,
 	setConfig,
 	setUserSetting,
+	softDeleteMemory,
 	updateWorkspace,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
@@ -74,7 +78,9 @@ admin.get("/filters", (c) => {
 	const userId = isAdmin ? undefined : c.get("userId");
 	const projects = listDistinctGitRemotes(userId);
 	const scopes = listDistinctScopes(userId);
-	return c.json({ projects, scopes });
+	const types = listDistinctMemoryTypes(userId);
+	const paths = listDistinctPaths(userId);
+	return c.json({ projects, scopes, types, paths });
 });
 
 // --- Search ---
@@ -132,23 +138,36 @@ admin.post("/search", async (c) => {
 admin.get("/memories", (c) => {
 	const gitRemote = c.req.query("git_remote");
 	const scope = c.req.query("scope");
+	const memoryType = c.req.query("memory_type");
+	const path = c.req.query("path");
 	const limit = Math.min(Math.max(Number(c.req.query("limit")) || 50, 1), 200);
 	const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
 	const isAdmin = c.get("role") === "admin";
+	// Only admins can view soft-deleted memories
+	const includeDeleted = isAdmin && c.req.query("include_deleted") === "true";
 	const userId = isAdmin ? undefined : c.get("userId");
 
-	const memories = listMemories({ gitRemote, scope, limit, offset, userId });
-	const total = countMemories({ gitRemote, scope, userId });
+	const memories = listMemories({
+		gitRemote,
+		scope,
+		memoryType,
+		path,
+		includeDeleted,
+		limit,
+		offset,
+		userId,
+	});
+	const total = countMemories({ gitRemote, scope, memoryType, includeDeleted, userId });
 
 	return c.json({ memories, total });
 });
 
-admin.delete("/memories/:id", async (c) => {
+admin.delete("/memories/:id", (c) => {
 	const id = c.req.param("id");
 
 	if (c.get("role") !== "admin") {
 		const userDb = new UserScope(c.get("userId"));
-		if (!userDb.deleteMemory(id)) {
+		if (!userDb.softDeleteMemory(id)) {
 			return c.json({ error: "Memory not found." }, 404);
 		}
 	} else {
@@ -156,19 +175,27 @@ admin.delete("/memories/:id", async (c) => {
 		if (!memory) {
 			return c.json({ error: "Memory not found." }, 404);
 		}
-		deleteMemory(id);
+		softDeleteMemory(id);
 	}
 
-	try {
-		await getStorageProvider().delete(id);
-	} catch (err) {
-		log.warn("Vector delete failed for {id}: {error}", {
-			id,
-			error: err instanceof Error ? err.message : String(err),
-		});
+	return c.json({ id, soft_deleted: true });
+});
+
+admin.post("/memories/:id/restore", (c) => {
+	const id = c.req.param("id");
+
+	if (c.get("role") !== "admin") {
+		const userDb = new UserScope(c.get("userId"));
+		if (!userDb.restoreMemory(id)) {
+			return c.json({ error: "Memory not found or not deleted." }, 404);
+		}
+	} else {
+		if (!restoreMemory(id)) {
+			return c.json({ error: "Memory not found or not deleted." }, 404);
+		}
 	}
 
-	return c.json({ id, deleted: true });
+	return c.json({ id, restored: true });
 });
 
 // --- Sessions ---

--- a/server/src/compression.ts
+++ b/server/src/compression.ts
@@ -89,6 +89,8 @@ export function parseSummary(summary: string): ParsedSummary {
 
 export interface CompressionProvider {
 	summarize(observations: ObservationRow[], project: string | null): Promise<string>;
+	/** Generic completion for short classification tasks. */
+	complete(prompt: string, maxTokens: number): Promise<string>;
 	readonly name: string;
 }
 
@@ -118,11 +120,8 @@ class AnthropicProvider implements CompressionProvider {
 		);
 	}
 
-	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
-		const observationText = formatObservations(observations, project);
-		const messages: AnthropicMessage[] = [
-			{ role: "user", content: `${COMPRESSION_PROMPT}\n\n${observationText}` },
-		];
+	private async call(content: string, maxTokens: number): Promise<string> {
+		const messages: AnthropicMessage[] = [{ role: "user", content }];
 
 		const res = await fetch("https://api.anthropic.com/v1/messages", {
 			method: "POST",
@@ -133,7 +132,7 @@ class AnthropicProvider implements CompressionProvider {
 			},
 			body: JSON.stringify({
 				model: this.model,
-				max_tokens: 800,
+				max_tokens: maxTokens,
 				messages,
 			}),
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -141,13 +140,22 @@ class AnthropicProvider implements CompressionProvider {
 
 		if (!res.ok) {
 			const body = await res.text();
-			throw new Error(`Anthropic compression failed (${res.status}): ${body}`);
+			throw new Error(`Anthropic call failed (${res.status}): ${body}`);
 		}
 
 		const data = (await res.json()) as AnthropicResponse;
 		const text = data.content.find((c) => c.type === "text")?.text;
 		if (!text) throw new Error("Anthropic returned empty content");
 		return text.trim();
+	}
+
+	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
+		const observationText = formatObservations(observations, project);
+		return this.call(`${COMPRESSION_PROMPT}\n\n${observationText}`, 800);
+	}
+
+	async complete(prompt: string, maxTokens: number): Promise<string> {
+		return this.call(prompt, maxTokens);
 	}
 }
 
@@ -180,9 +188,7 @@ class OpenRouterProvider implements CompressionProvider {
 		);
 	}
 
-	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
-		const observationText = formatObservations(observations, project);
-
+	private async call(content: string, maxTokens: number): Promise<string> {
 		const res = await fetch(`${this.baseUrl}/chat/completions`, {
 			method: "POST",
 			headers: {
@@ -191,21 +197,30 @@ class OpenRouterProvider implements CompressionProvider {
 			},
 			body: JSON.stringify({
 				model: this.model,
-				max_tokens: 800,
-				messages: [{ role: "user", content: `${COMPRESSION_PROMPT}\n\n${observationText}` }],
+				max_tokens: maxTokens,
+				messages: [{ role: "user", content }],
 			}),
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
 
 		if (!res.ok) {
 			const body = await res.text();
-			throw new Error(`OpenRouter compression failed (${res.status}): ${body}`);
+			throw new Error(`OpenRouter call failed (${res.status}): ${body}`);
 		}
 
 		const data = (await res.json()) as ChatCompletionResponse;
 		const text = data.choices?.[0]?.message?.content;
 		if (!text) throw new Error("OpenRouter returned empty content");
 		return text.trim();
+	}
+
+	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
+		const observationText = formatObservations(observations, project);
+		return this.call(`${COMPRESSION_PROMPT}\n\n${observationText}`, 800);
+	}
+
+	async complete(prompt: string, maxTokens: number): Promise<string> {
+		return this.call(prompt, maxTokens);
 	}
 }
 
@@ -228,29 +243,36 @@ class OllamaProvider implements CompressionProvider {
 		return getConfigWithEnv("compression_model", "HUSK_COMPRESSION_MODEL") ?? "llama3.2";
 	}
 
-	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
-		const observationText = formatObservations(observations, project);
-
+	private async call(content: string): Promise<string> {
 		const res = await fetch(`${this.url}/api/chat`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				model: this.model,
 				stream: false,
-				messages: [{ role: "user", content: `${COMPRESSION_PROMPT}\n\n${observationText}` }],
+				messages: [{ role: "user", content }],
 			}),
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
 
 		if (!res.ok) {
 			const body = await res.text();
-			throw new Error(`Ollama compression failed (${res.status}): ${body}`);
+			throw new Error(`Ollama call failed (${res.status}): ${body}`);
 		}
 
 		const data = (await res.json()) as OllamaChatResponse;
 		const text = data.message?.content;
 		if (!text) throw new Error("Ollama returned empty content");
 		return text.trim();
+	}
+
+	async summarize(observations: ObservationRow[], project: string | null): Promise<string> {
+		const observationText = formatObservations(observations, project);
+		return this.call(`${COMPRESSION_PROMPT}\n\n${observationText}`);
+	}
+
+	async complete(prompt: string, _maxTokens: number): Promise<string> {
+		return this.call(prompt);
 	}
 }
 
@@ -321,6 +343,106 @@ export function getCompressionProvider(): CompressionProvider {
 
 export function setCompressionProvider(p: CompressionProvider | null): void {
 	provider = p;
+}
+
+// --- Memory classification ---
+
+import { MEMORY_TYPES, type MemoryType, generateUniqueSlug, isValidMemoryType } from "./db.js";
+
+const CLASSIFICATION_PROMPT = `Classify the following memory content. Respond with ONLY a valid JSON object, no markdown fences.
+
+Fields:
+- "title": A concise title, max 60 characters
+- "memory_type": One of: decision, solution, lesson, fact, convention, goal
+- "path": A hierarchical category path like "auth/" or "api/rate-limits/" (lowercase, max 3 segments, trailing slash). Use "" if uncategorizable.
+
+Memory content:
+`;
+
+export interface MemoryClassification {
+	title: string;
+	slug: string;
+	memory_type: MemoryType;
+	path: string;
+}
+
+export function slugify(text: string): string {
+	const slug = text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80);
+	return slug || "memory";
+}
+
+interface ClassificationResponse {
+	title?: string;
+	memory_type?: string;
+	path?: string;
+}
+
+export async function classifyMemory(
+	summary: string,
+	scope: string,
+	gitRemote: string | null,
+	opts?: { title?: string; memoryType?: string; path?: string },
+): Promise<MemoryClassification> {
+	const needsLlm = !opts?.title || !opts?.memoryType;
+
+	let title = opts?.title ?? null;
+	const rawType = opts?.memoryType ?? "";
+	let memoryType: MemoryType = isValidMemoryType(rawType) ? rawType : "fact";
+	let path = opts?.path ?? "";
+
+	// Session-scoped memories skip LLM classification
+	if (scope === "session") {
+		title = title ?? summary.slice(0, 60);
+		const slug = slugify(title);
+		return {
+			title,
+			slug: generateUniqueSlug(scope, gitRemote, slug),
+			memory_type: memoryType,
+			path,
+		};
+	}
+
+	if (needsLlm) {
+		try {
+			const compressionProvider = getCompressionProvider();
+			const raw = await compressionProvider.complete(
+				`${CLASSIFICATION_PROMPT}${summary.slice(0, 2000)}`,
+				200,
+			);
+
+			// Strip markdown fences if present
+			const jsonStr = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+			const parsed = JSON.parse(jsonStr) as ClassificationResponse;
+
+			if (!title && parsed.title && typeof parsed.title === "string") {
+				title = parsed.title.slice(0, 60);
+			}
+			if (!opts?.memoryType && parsed.memory_type && isValidMemoryType(parsed.memory_type)) {
+				memoryType = parsed.memory_type as MemoryType;
+			}
+			if (!opts?.path && parsed.path && typeof parsed.path === "string") {
+				path = parsed.path.slice(0, 100);
+			}
+		} catch (err) {
+			log.warn("Memory classification failed, using defaults: {error}", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	title = title ?? summary.slice(0, 60);
+	const slug = slugify(title);
+
+	return {
+		title,
+		slug: generateUniqueSlug(scope, gitRemote, slug),
+		memory_type: memoryType,
+		path,
+	};
 }
 
 // --- Config helpers ---

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -206,6 +206,27 @@ export function initDb(path?: string): Database {
 	}
 	db.run("CREATE INDEX IF NOT EXISTS idx_memories_workspace ON memories(workspace_id)");
 
+	// Migration: add structured memory columns (title, slug, memory_type, path, updated_at, deleted_at)
+	const memColNames = new Set(memCols.map((c) => c.name));
+	if (!memColNames.has("title")) {
+		db.run("ALTER TABLE memories ADD COLUMN title TEXT");
+		db.run("ALTER TABLE memories ADD COLUMN slug TEXT");
+		db.run("ALTER TABLE memories ADD COLUMN memory_type TEXT");
+		db.run("ALTER TABLE memories ADD COLUMN path TEXT");
+		db.run("ALTER TABLE memories ADD COLUMN updated_at TEXT");
+		db.run("ALTER TABLE memories ADD COLUMN deleted_at TEXT");
+	}
+	db.run(
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_slug ON memories(scope, git_remote, slug) WHERE slug IS NOT NULL AND deleted_at IS NULL",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type) WHERE memory_type IS NOT NULL",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_memories_deleted ON memories(deleted_at) WHERE deleted_at IS NOT NULL",
+	);
+	db.run("CREATE INDEX IF NOT EXISTS idx_memories_path ON memories(path) WHERE path IS NOT NULL");
+
 	db.run(`
 		CREATE TABLE IF NOT EXISTS user_settings (
 			user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -397,6 +418,20 @@ export function updateKeyLastUsed(id: string) {
 
 // --- Memories ---
 
+export const MEMORY_TYPES = [
+	"decision",
+	"solution",
+	"lesson",
+	"fact",
+	"convention",
+	"goal",
+] as const;
+export type MemoryType = (typeof MEMORY_TYPES)[number];
+
+export function isValidMemoryType(value: string): value is MemoryType {
+	return MEMORY_TYPES.includes(value as MemoryType);
+}
+
 export interface MemoryRow {
 	id: string;
 	api_key_id: string;
@@ -407,6 +442,12 @@ export interface MemoryRow {
 	created_at: string;
 	expires_at: string | null;
 	workspace_id: string | null;
+	title: string | null;
+	slug: string | null;
+	memory_type: string | null;
+	path: string | null;
+	updated_at: string | null;
+	deleted_at: string | null;
 }
 
 export function createMemory(params: {
@@ -418,9 +459,14 @@ export function createMemory(params: {
 	metadata?: string | null;
 	expiresAt?: string | null;
 	workspaceId?: string | null;
+	title?: string | null;
+	slug?: string | null;
+	memoryType?: string | null;
+	path?: string | null;
 }): string {
 	db.query(
-		"INSERT INTO memories (id, api_key_id, git_remote, scope, summary, metadata, expires_at, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		`INSERT INTO memories (id, api_key_id, git_remote, scope, summary, metadata, expires_at, workspace_id, title, slug, memory_type, path)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	).run(
 		params.id,
 		params.apiKeyId,
@@ -430,11 +476,19 @@ export function createMemory(params: {
 		params.metadata ?? null,
 		params.expiresAt ?? null,
 		params.workspaceId ?? null,
+		params.title ?? null,
+		params.slug ?? null,
+		params.memoryType ?? null,
+		params.path ?? null,
 	);
 	return params.id;
 }
 
-const EXPIRY_FILTER = "(m.expires_at IS NULL OR m.expires_at > datetime('now'))";
+const ACTIVE_FILTER =
+	"(m.expires_at IS NULL OR m.expires_at > datetime('now')) AND m.deleted_at IS NULL";
+
+/** @deprecated Use ACTIVE_FILTER instead */
+const EXPIRY_FILTER = ACTIVE_FILTER;
 
 /** @internal System use only — user-facing code should use UserScope */
 export function getMemory(id: string): MemoryRow | undefined {
@@ -461,9 +515,19 @@ export function listMemories(opts?: {
 	limit?: number;
 	offset?: number;
 	userId?: string;
+	memoryType?: string;
+	path?: string;
+	includeDeleted?: boolean;
 }): MemoryRow[] {
-	const conditions: string[] = [EXPIRY_FILTER];
+	const conditions: string[] = [];
 	const params: (string | number)[] = [];
+
+	if (opts?.includeDeleted) {
+		// Only apply expiry filter, show deleted
+		conditions.push("(m.expires_at IS NULL OR m.expires_at > datetime('now'))");
+	} else {
+		conditions.push(ACTIVE_FILTER);
+	}
 
 	if (opts?.gitRemote) {
 		conditions.push("m.git_remote = ?");
@@ -476,6 +540,14 @@ export function listMemories(opts?: {
 	if (opts?.userId) {
 		conditions.push("ak.user_id = ?");
 		params.push(opts.userId);
+	}
+	if (opts?.memoryType) {
+		conditions.push("m.memory_type = ?");
+		params.push(opts.memoryType);
+	}
+	if (opts?.path) {
+		conditions.push("(m.path = ? OR m.path LIKE ?)");
+		params.push(opts.path, `${opts.path}%`);
 	}
 
 	const needsJoin = opts?.userId != null;
@@ -495,7 +567,93 @@ export function listMemories(opts?: {
 }
 
 export function updateMemorySummary(id: string, summary: string): void {
-	db.query("UPDATE memories SET summary = ? WHERE id = ?").run(summary, id);
+	db.query("UPDATE memories SET summary = ?, updated_at = datetime('now') WHERE id = ?").run(
+		summary,
+		id,
+	);
+}
+
+export function updateMemoryFields(
+	id: string,
+	fields: {
+		title?: string | null;
+		slug?: string | null;
+		memoryType?: string | null;
+		path?: string | null;
+		summary?: string;
+	},
+): void {
+	const sets: string[] = ["updated_at = datetime('now')"];
+	const params: (string | null)[] = [];
+
+	if (fields.title !== undefined) {
+		sets.push("title = ?");
+		params.push(fields.title);
+	}
+	if (fields.slug !== undefined) {
+		sets.push("slug = ?");
+		params.push(fields.slug);
+	}
+	if (fields.memoryType !== undefined) {
+		sets.push("memory_type = ?");
+		params.push(fields.memoryType);
+	}
+	if (fields.path !== undefined) {
+		sets.push("path = ?");
+		params.push(fields.path);
+	}
+	if (fields.summary !== undefined) {
+		sets.push("summary = ?");
+		params.push(fields.summary);
+	}
+
+	params.push(id);
+	db.query(`UPDATE memories SET ${sets.join(", ")} WHERE id = ?`).run(...params);
+}
+
+/** Soft-delete a memory by setting deleted_at. */
+export function softDeleteMemory(id: string): boolean {
+	const result = db
+		.query("UPDATE memories SET deleted_at = datetime('now') WHERE id = ? AND deleted_at IS NULL")
+		.run(id);
+	return result.changes > 0;
+}
+
+/** Restore a soft-deleted memory. */
+export function restoreMemory(id: string): boolean {
+	const result = db
+		.query("UPDATE memories SET deleted_at = NULL WHERE id = ? AND deleted_at IS NOT NULL")
+		.run(id);
+	return result.changes > 0;
+}
+
+/** Generate a unique slug within (scope, git_remote), appending -2, -3, etc. on collision. */
+export function generateUniqueSlug(
+	scope: string,
+	gitRemote: string | null,
+	baseSlug: string,
+): string {
+	let slug = baseSlug;
+	let suffix = 2;
+
+	const remoteCondition = gitRemote === null ? "git_remote IS NULL" : "git_remote = ?";
+	const sql = `SELECT COUNT(*) as count FROM memories WHERE scope = ? AND ${remoteCondition} AND slug = ? AND deleted_at IS NULL`;
+
+	if (gitRemote === null) {
+		const check = db.prepare<{ count: number }, [string, string]>(sql);
+		while ((check.get(scope, slug)?.count ?? 0) > 0) {
+			slug = `${baseSlug}-${suffix}`;
+			suffix++;
+		}
+	} else {
+		const check = db.prepare<{ count: number }, [string, string, string]>(sql);
+		while ((check.get(scope, gitRemote, slug)?.count ?? 0) > 0) {
+			slug = `${baseSlug}-${suffix}`;
+			suffix++;
+		}
+	}
+
+	return slug;
 }
 
 /** @internal System use only — user-facing code should use UserScope */
@@ -510,6 +668,16 @@ export function getExpiredMemoryIds(limit: number): string[] {
 			"SELECT id FROM memories WHERE expires_at IS NOT NULL AND expires_at < datetime('now') LIMIT ?",
 		)
 		.all(limit);
+	return rows.map((r) => r.id);
+}
+
+/** Find soft-deleted memories past the grace period for hard purge. */
+export function getSoftDeletedMemoryIds(graceDays: number, limit: number): string[] {
+	const rows = db
+		.query<{ id: string }, [string, number]>(
+			"SELECT id FROM memories WHERE deleted_at IS NOT NULL AND deleted_at < datetime('now', '-' || ? || ' days') LIMIT ?",
+		)
+		.all(String(graceDays), limit);
 	return rows.map((r) => r.id);
 }
 
@@ -552,13 +720,55 @@ export function listDistinctScopes(userId?: string): string[] {
 	return rows.map((r) => r.scope);
 }
 
+export function listDistinctMemoryTypes(userId?: string): string[] {
+	if (userId) {
+		const rows = db
+			.query<{ memory_type: string }, [string]>(
+				"SELECT DISTINCT m.memory_type FROM memories m JOIN api_keys ak ON m.api_key_id = ak.id WHERE m.memory_type IS NOT NULL AND m.deleted_at IS NULL AND ak.user_id = ? ORDER BY m.memory_type",
+			)
+			.all(userId);
+		return rows.map((r) => r.memory_type);
+	}
+	const rows = db
+		.query<{ memory_type: string }, []>(
+			"SELECT DISTINCT memory_type FROM memories WHERE memory_type IS NOT NULL AND deleted_at IS NULL ORDER BY memory_type",
+		)
+		.all();
+	return rows.map((r) => r.memory_type);
+}
+
+export function listDistinctPaths(userId?: string): string[] {
+	if (userId) {
+		const rows = db
+			.query<{ path: string }, [string]>(
+				"SELECT DISTINCT m.path FROM memories m JOIN api_keys ak ON m.api_key_id = ak.id WHERE m.path IS NOT NULL AND m.path != '' AND m.deleted_at IS NULL AND ak.user_id = ? ORDER BY m.path",
+			)
+			.all(userId);
+		return rows.map((r) => r.path);
+	}
+	const rows = db
+		.query<{ path: string }, []>(
+			"SELECT DISTINCT path FROM memories WHERE path IS NOT NULL AND path != '' AND deleted_at IS NULL ORDER BY path",
+		)
+		.all();
+	return rows.map((r) => r.path);
+}
+
 export function countMemories(opts?: {
 	gitRemote?: string;
 	scope?: string;
 	userId?: string;
+	memoryType?: string;
+	includeDeleted?: boolean;
 }): number {
-	const conditions: string[] = [EXPIRY_FILTER];
+	const conditions: string[] = [];
 	const params: string[] = [];
+
+	if (opts?.includeDeleted) {
+		conditions.push("(m.expires_at IS NULL OR m.expires_at > datetime('now'))");
+	} else {
+		conditions.push(ACTIVE_FILTER);
+	}
 
 	if (opts?.gitRemote) {
 		conditions.push("m.git_remote = ?");
@@ -571,6 +781,10 @@ export function countMemories(opts?: {
 	if (opts?.userId) {
 		conditions.push("ak.user_id = ?");
 		params.push(opts.userId);
+	}
+	if (opts?.memoryType) {
+		conditions.push("m.memory_type = ?");
+		params.push(opts.memoryType);
 	}
 
 	const needsJoin = opts?.userId != null;
@@ -1246,11 +1460,19 @@ export class UserScope {
 		scope?: string;
 		limit?: number;
 		offset?: number;
+		memoryType?: string;
+		path?: string;
+		includeDeleted?: boolean;
 	}): MemoryRow[] {
 		return listMemories({ ...opts, userId: this.userId });
 	}
 
-	countMemories(opts?: { gitRemote?: string; scope?: string }): number {
+	countMemories(opts?: {
+		gitRemote?: string;
+		scope?: string;
+		memoryType?: string;
+		includeDeleted?: boolean;
+	}): number {
 		return countMemories({ ...opts, userId: this.userId });
 	}
 
@@ -1258,6 +1480,23 @@ export class UserScope {
 		const memory = getMemoryForUser(id, this.userId);
 		if (!memory) return false;
 		return deleteMemory(id);
+	}
+
+	softDeleteMemory(id: string): boolean {
+		const memory = getMemoryForUser(id, this.userId);
+		if (!memory) return false;
+		return softDeleteMemory(id);
+	}
+
+	restoreMemory(id: string): boolean {
+		// For restore, check ownership even on deleted memories
+		const row = db
+			.query<MemoryRow, [string, string]>(
+				"SELECT m.* FROM memories m JOIN api_keys k ON m.api_key_id = k.id WHERE m.id = ? AND k.user_id = ? AND m.deleted_at IS NOT NULL",
+			)
+			.get(id, this.userId);
+		if (!row) return false;
+		return restoreMemory(id);
 	}
 
 	listGitRemotes(): string[] {

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -1,17 +1,24 @@
+import { getLogger } from "@logtape/logtape";
 import { Hono } from "hono";
 import { bearerKeyMiddleware } from "./auth.js";
+import { classifyMemory, slugify } from "./compression.js";
 import {
 	createMemory,
+	generateUniqueSlug,
 	getConfigWithEnv,
 	getMemory,
 	getMemoryForUser,
 	getUserSetting,
+	isValidMemoryType,
+	updateMemoryFields,
 	updateMemorySummary,
 } from "./db.js";
 import { getProvider } from "./embeddings.js";
 import type { AppEnv } from "./env.js";
 import { getStorageProvider } from "./storage.js";
 import { resolveWorkspace } from "./workspace.js";
+
+const log = getLogger(["husk", "ingest"]);
 
 const VALID_SCOPES = ["session", "project", "workspace", "global"] as const;
 type Scope = (typeof VALID_SCOPES)[number];
@@ -88,6 +95,9 @@ interface StoreMemoryParams {
 	replace?: string;
 	ttl?: number | null;
 	workspaceId?: string | null;
+	title?: string;
+	memoryType?: string;
+	path?: string;
 }
 
 interface StoredMemory {
@@ -97,6 +107,10 @@ interface StoredMemory {
 	git_remote: string | null;
 	created_at: string;
 	expires_at: string | null;
+	title: string | null;
+	slug: string | null;
+	memory_type: string | null;
+	path: string | null;
 }
 
 export interface DuplicateMemory {
@@ -143,7 +157,31 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 			throw new StoreMemoryError("Memory to replace not found.", "validation");
 		}
 
-		updateMemorySummary(params.replace, params.summary);
+		// Re-classify on replace
+		let classification: { title: string; slug: string; memory_type: string; path: string };
+		try {
+			classification = await classifyMemory(params.summary, scope, gitRemote, {
+				title: params.title,
+				memoryType: params.memoryType,
+				path: params.path,
+			});
+		} catch {
+			const fallbackTitle = params.title ?? params.summary.slice(0, 60);
+			classification = {
+				title: fallbackTitle,
+				slug: generateUniqueSlug(scope, gitRemote, slugify(fallbackTitle)),
+				memory_type: params.memoryType ?? "fact",
+				path: params.path ?? "",
+			};
+		}
+
+		updateMemoryFields(params.replace, {
+			summary: params.summary,
+			title: classification.title,
+			slug: classification.slug,
+			memoryType: classification.memory_type,
+			path: classification.path,
+		});
 
 		try {
 			await getStorageProvider().upsert(params.replace, vector, {
@@ -155,6 +193,9 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 				created_at: existing.created_at,
 				expires_at: expiresAt,
 				workspace_id: workspaceId,
+				title: classification.title,
+				memory_type: classification.memory_type,
+				path: classification.path,
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : "Unknown error";
@@ -168,6 +209,10 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 			git_remote: gitRemote,
 			created_at: existing.created_at,
 			expires_at: expiresAt,
+			title: classification.title,
+			slug: classification.slug,
+			memory_type: classification.memory_type,
+			path: classification.path,
 		};
 	}
 
@@ -192,6 +237,27 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 		}
 	}
 
+	// Auto-classify
+	let classification: { title: string; slug: string; memory_type: string; path: string };
+	try {
+		classification = await classifyMemory(params.summary, scope, gitRemote, {
+			title: params.title,
+			memoryType: params.memoryType,
+			path: params.path,
+		});
+	} catch (err) {
+		log.warn("Memory classification failed, using defaults: {error}", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		const fallbackTitle = params.title ?? params.summary.slice(0, 60);
+		classification = {
+			title: fallbackTitle,
+			slug: generateUniqueSlug(scope, gitRemote, slugify(fallbackTitle)),
+			memory_type: params.memoryType ?? "fact",
+			path: params.path ?? "",
+		};
+	}
+
 	const id = crypto.randomUUID();
 	const createdAt = new Date().toISOString();
 
@@ -204,6 +270,10 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 		metadata,
 		expiresAt,
 		workspaceId,
+		title: classification.title,
+		slug: classification.slug,
+		memoryType: classification.memory_type,
+		path: classification.path,
 	});
 
 	try {
@@ -216,6 +286,9 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 			created_at: createdAt,
 			expires_at: expiresAt,
 			workspace_id: workspaceId,
+			title: classification.title,
+			memory_type: classification.memory_type,
+			path: classification.path,
 		});
 	} catch (err) {
 		const message = err instanceof Error ? err.message : "Unknown error";
@@ -229,6 +302,10 @@ export async function storeMemory(params: StoreMemoryParams): Promise<StoreMemor
 		git_remote: gitRemote,
 		created_at: createdAt,
 		expires_at: expiresAt,
+		title: classification.title,
+		slug: classification.slug,
+		memory_type: classification.memory_type,
+		path: classification.path,
 	};
 }
 
@@ -251,6 +328,9 @@ interface IngestBody {
 	force?: boolean;
 	replace?: string;
 	ttl?: number | null;
+	title?: string;
+	memory_type?: string;
+	path?: string;
 }
 
 const ingest = new Hono<AppEnv>();
@@ -266,6 +346,15 @@ ingest.post("/", async (c) => {
 	}
 	if (summary.length > 10_000) {
 		return c.json({ error: "Summary must be 10,000 characters or fewer." }, 400);
+	}
+	if (body.memory_type && !isValidMemoryType(body.memory_type)) {
+		return c.json(
+			{
+				error:
+					"Invalid memory_type. Must be one of: decision, solution, lesson, fact, convention, goal.",
+			},
+			400,
+		);
 	}
 
 	const apiKey = c.get("apiKey");
@@ -294,6 +383,9 @@ ingest.post("/", async (c) => {
 			replace: body.replace,
 			ttl: body.ttl,
 			workspaceId,
+			title: body.title,
+			memoryType: body.memory_type,
+			path: body.path,
 		});
 
 		if (isDuplicate(result)) {

--- a/server/src/mcp.test.ts
+++ b/server/src/mcp.test.ts
@@ -341,8 +341,9 @@ describe("MCP server", () => {
 
 		expect(data.result?.isError).toBeUndefined();
 		const text = data.result?.content?.[0]?.text;
-		const parsed = JSON.parse(text ?? "{}") as { id: string; deleted: boolean };
-		expect(parsed.deleted).toBe(true);
+		const parsed = JSON.parse(text ?? "{}") as { id: string; soft_deleted: boolean };
+		expect(parsed.soft_deleted).toBe(true);
+		// Soft-deleted memories are excluded from active queries
 		expect(getMemory(id)).toBeUndefined();
 	});
 

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -7,6 +7,7 @@ import type { ValidatedApiKey } from "./auth.js";
 import { validateBearerKey } from "./auth.js";
 import { parseSummary } from "./compression.js";
 import {
+	MEMORY_TYPES,
 	UserScope,
 	countObservations,
 	getRecentSessionSummaries,
@@ -79,6 +80,10 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					.describe("Filter by scope"),
 				project: z.string().optional().describe("Filter by git remote / project"),
 				workspace: z.string().optional().describe("Filter by workspace name or ID"),
+				type: z
+					.enum(MEMORY_TYPES)
+					.optional()
+					.describe("Filter by memory type (decision/solution/lesson/fact/convention/goal)"),
 				limit: z.number().int().min(1).max(50).optional().describe("Max results (default 10)"),
 				max_tokens: z
 					.number()
@@ -121,7 +126,11 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 				}
 
 				const now = new Date().toISOString();
-				const filterExpired = (results: { score: number; payload: Record<string, unknown> }[]) =>
+				// Filter results that have expired based on payload TTL.
+				// Soft-deleted memories may still appear until the retention
+				// sweep hard-purges them (default 30 days). This is by design:
+				// vectors are kept for instant restore capability.
+				const filterActive = (results: { score: number; payload: Record<string, unknown> }[]) =>
 					results.filter((r) => {
 						const expiresAt = r.payload?.expires_at;
 						return !expiresAt || String(expiresAt) > now;
@@ -154,10 +163,11 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 								scope: tier.scope,
 								user_id: apiKey.user_id,
 								workspace_id: tier.workspace_id,
+								memory_type: args.type,
 							},
 							20,
 						);
-						for (const r of filterExpired(results)) {
+						for (const r of filterActive(results)) {
 							const id = String(r.payload.memory_id ?? r.payload.id ?? "");
 							if (id && seen.has(id)) continue;
 							if (id) seen.add(id);
@@ -183,11 +193,12 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 							scope: args.scope,
 							user_id: apiKey.user_id,
 							workspace_id: args.scope === "workspace" ? workspaceId : undefined,
+							memory_type: args.type,
 						},
 						fetchLimit,
 					);
 
-					memories = filterExpired(results).map((r) => ({
+					memories = filterActive(results).map((r) => ({
 						score: r.score,
 						...(r.payload ?? {}),
 					}));
@@ -224,7 +235,7 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 		"remember",
 		{
 			description:
-				"Store a new memory. Checks for duplicates — if a similar memory exists, returns it instead of storing. Use force to skip the check, or replace to overwrite an existing memory. Cost: embedding call + vector search + DB write, no LLM.",
+				"Store a new memory. Auto-classifies with title, type, and path. Checks for duplicates — if a similar memory exists, returns it instead of storing. Use force to skip the check, or replace to overwrite an existing memory. Cost: embedding call + vector search + DB write + optional LLM classification.",
 			inputSchema: {
 				content: z.string().describe("The content to remember"),
 				scope: z
@@ -245,6 +256,20 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					.describe(
 						"TTL in seconds. 0 or omitted = scope default (session: 90d, all others: forever). Admin can set HUSK_TTL_MAX to cap all TTLs.",
 					),
+				title: z
+					.string()
+					.max(60)
+					.optional()
+					.describe("Override auto-generated title (max 60 chars)"),
+				type: z
+					.enum(MEMORY_TYPES)
+					.optional()
+					.describe("Override auto-generated type (decision/solution/lesson/fact/convention/goal)"),
+				path: z
+					.string()
+					.max(100)
+					.optional()
+					.describe("Tree path for organization, e.g. 'auth/' or 'api/rate-limits/'"),
 			},
 		},
 		async (args) => {
@@ -267,6 +292,9 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 					replace: args.replace,
 					ttl: args.ttl,
 					workspaceId,
+					title: args.title,
+					memoryType: args.type,
+					path: args.path,
 				});
 
 				if (isDuplicate(result)) {
@@ -318,42 +346,58 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 		"forget",
 		{
 			description:
-				"Delete a memory by ID. Use search first to find memory IDs. Cost: DB write + vector delete, no LLM.",
+				"Soft-delete a memory by ID. The memory can be restored within 30 days. Use search first to find memory IDs. Cost: DB write only, no LLM.",
 			inputSchema: {
-				id: z.string().describe("The memory ID to delete (returned by search)"),
+				id: z.string().describe("The memory ID to soft-delete (returned by search)"),
 			},
 		},
-		async (args) => {
-			if (!db.deleteMemory(args.id)) {
+		(args) => {
+			if (!db.softDeleteMemory(args.id)) {
 				return {
 					isError: true,
 					content: [{ type: "text" as const, text: "Memory not found." }],
 				};
 			}
 
-			try {
-				await getStorageProvider().delete(args.id);
-			} catch (err) {
-				log.warn("Vector delete failed for {id}: {error}", {
-					id: args.id,
-					error: err instanceof Error ? err.message : String(err),
-				});
-			}
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify({
+							id: args.id,
+							soft_deleted: true,
+							restore_until: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+						}),
+					},
+				],
+			};
+		},
+	);
 
-			const graphProvider = getGraphProviderOrNull();
-			if (graphProvider) {
-				try {
-					await graphProvider.removeEdgesForMemory(args.id);
-				} catch (err) {
-					log.warn("Graph edge cleanup failed for {id}: {error}", {
-						id: args.id,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				}
+	server.registerTool(
+		"restore",
+		{
+			description:
+				"Restore a soft-deleted memory by ID. Only works within the 30-day grace period. Cost: DB write only, no LLM.",
+			inputSchema: {
+				id: z.string().describe("The memory ID to restore"),
+			},
+		},
+		(args) => {
+			if (!db.restoreMemory(args.id)) {
+				return {
+					isError: true,
+					content: [{ type: "text" as const, text: "Memory not found or not deleted." }],
+				};
 			}
 
 			return {
-				content: [{ type: "text" as const, text: JSON.stringify({ id: args.id, deleted: true }) }],
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify({ id: args.id, restored: true }),
+					},
+				],
 			};
 		},
 	);
@@ -380,13 +424,19 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 		"list_memories",
 		{
 			description:
-				"List all memories, optionally filtered by project and/or scope. Returns full memory objects with IDs. Use for auditing, cleanup, or bulk review. Cost: DB read only, no LLM.",
+				"List all memories, optionally filtered by project, scope, type, or path. Returns full memory objects with IDs. Use for auditing, cleanup, or bulk review. Cost: DB read only, no LLM.",
 			inputSchema: {
 				project: z.string().optional().describe("Filter by git remote / project"),
 				scope: z
 					.enum(["session", "project", "workspace", "global"])
 					.optional()
 					.describe("Filter by scope"),
+				type: z.enum(MEMORY_TYPES).optional().describe("Filter by memory type"),
+				path: z.string().optional().describe("Filter by path prefix (e.g. 'auth/')"),
+				include_deleted: z
+					.boolean()
+					.optional()
+					.describe("Include soft-deleted memories (default false)"),
 				limit: z.number().int().min(1).max(200).optional().describe("Max results (default 50)"),
 				offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)"),
 			},
@@ -397,12 +447,17 @@ function createMcpServer(apiKey: ValidatedApiKey): McpServer {
 			const memories = db.listMemories({
 				gitRemote: args.project,
 				scope: args.scope,
+				memoryType: args.type,
+				path: args.path,
+				includeDeleted: args.include_deleted,
 				limit,
 				offset,
 			});
 			const total = db.countMemories({
 				gitRemote: args.project,
 				scope: args.scope,
+				memoryType: args.type,
+				includeDeleted: args.include_deleted,
 			});
 
 			return {

--- a/server/src/retention.ts
+++ b/server/src/retention.ts
@@ -1,5 +1,10 @@
 import { getLogger } from "@logtape/logtape";
-import { deleteMemoriesBatch, getExpiredMemoryIds } from "./db.js";
+import {
+	deleteMemoriesBatch,
+	getConfigWithEnv,
+	getExpiredMemoryIds,
+	getSoftDeletedMemoryIds,
+} from "./db.js";
 import { getGraphProviderOrNull } from "./graph.js";
 import { getStorageProvider } from "./storage.js";
 
@@ -68,6 +73,58 @@ export async function sweepExpiredMemories(): Promise<number> {
 	// If batch was full, there might be more — schedule another pass
 	if (ids.length === BATCH_SIZE) {
 		const more = await sweepExpiredMemories();
+		return ids.length + more;
+	}
+
+	// Hard-purge soft-deleted memories past grace period
+	const purged = await purgeSoftDeletedMemories();
+	return ids.length + purged;
+}
+
+const DEFAULT_SOFT_DELETE_GRACE_DAYS = 30;
+
+async function purgeSoftDeletedMemories(): Promise<number> {
+	const graceDaysStr = getConfigWithEnv("soft_delete_grace_days", "HUSK_SOFT_DELETE_GRACE_DAYS");
+	const graceDays = graceDaysStr
+		? Math.max(Number(graceDaysStr), 1)
+		: DEFAULT_SOFT_DELETE_GRACE_DAYS;
+
+	const ids = getSoftDeletedMemoryIds(graceDays, BATCH_SIZE);
+	if (ids.length === 0) return 0;
+
+	deleteMemoriesBatch(ids);
+
+	const graphProvider = getGraphProviderOrNull();
+
+	for (const id of ids) {
+		try {
+			await getStorageProvider().delete(id);
+		} catch (err) {
+			log.warn("Vector delete failed for purged memory {id}: {error}", {
+				id,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+
+		if (graphProvider) {
+			try {
+				await graphProvider.removeEdgesForMemory(id);
+			} catch (err) {
+				log.warn("Graph edge cleanup failed for purged memory {id}: {error}", {
+					id,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+	}
+
+	log.info("Purged {count} soft-deleted memories (grace: {days}d)", {
+		count: ids.length,
+		days: graceDays,
+	});
+
+	if (ids.length === BATCH_SIZE) {
+		const more = await purgeSoftDeletedMemories();
 		return ids.length + more;
 	}
 

--- a/server/src/storage-qdrant.ts
+++ b/server/src/storage-qdrant.ts
@@ -55,6 +55,9 @@ export class QdrantStorageProvider implements StorageProvider {
 		if (filter?.workspace_id) {
 			must.push({ key: "workspace_id", match: { value: filter.workspace_id } });
 		}
+		if (filter?.memory_type) {
+			must.push({ key: "memory_type", match: { value: filter.memory_type } });
+		}
 
 		const results = await client.search(COLLECTION_NAME, {
 			vector,

--- a/server/src/storage-sqlite-vec.ts
+++ b/server/src/storage-sqlite-vec.ts
@@ -199,6 +199,7 @@ export class SqliteVecStorageProvider implements StorageProvider {
 				if (filter.git_remote && entry.payload.git_remote !== filter.git_remote) continue;
 				if (filter.scope && entry.payload.scope !== filter.scope) continue;
 				if (filter.workspace_id && entry.payload.workspace_id !== filter.workspace_id) continue;
+				if (filter.memory_type && entry.payload.memory_type !== filter.memory_type) continue;
 			}
 
 			results.push({

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -20,6 +20,7 @@ export interface MemoryFilter {
 	scope?: string;
 	user_id?: string;
 	workspace_id?: string;
+	memory_type?: string;
 }
 
 export interface VectorSearchResult {

--- a/server/ui/src/api.ts
+++ b/server/ui/src/api.ts
@@ -117,6 +117,12 @@ export interface Memory {
 	metadata: string | null;
 	created_at: string;
 	workspace_id: string | null;
+	title: string | null;
+	slug: string | null;
+	memory_type: string | null;
+	path: string | null;
+	updated_at: string | null;
+	deleted_at: string | null;
 }
 
 export interface MemoriesResponse {
@@ -151,6 +157,8 @@ export interface WorkspacesResponse {
 export interface FiltersResponse {
 	projects: string[];
 	scopes: string[];
+	types: string[];
+	paths: string[];
 }
 
 export interface SearchResult {
@@ -287,12 +295,18 @@ export const api = {
 	listMemories(opts?: {
 		git_remote?: string;
 		scope?: string;
+		memory_type?: string;
+		path?: string;
+		include_deleted?: boolean;
 		limit?: number;
 		offset?: number;
 	}) {
 		const params = new URLSearchParams();
 		if (opts?.git_remote) params.set("git_remote", opts.git_remote);
 		if (opts?.scope) params.set("scope", opts.scope);
+		if (opts?.memory_type) params.set("memory_type", opts.memory_type);
+		if (opts?.path) params.set("path", opts.path);
+		if (opts?.include_deleted) params.set("include_deleted", "true");
 		if (opts?.limit) params.set("limit", String(opts.limit));
 		if (opts?.offset) params.set("offset", String(opts.offset));
 		const qs = params.toString();
@@ -307,9 +321,17 @@ export const api = {
 	},
 
 	deleteMemory(id: string) {
-		return request<{ id: string; deleted: true }>(`/api/admin/memories/${encodeURIComponent(id)}`, {
-			method: "DELETE",
-		});
+		return request<{ id: string; soft_deleted: true }>(
+			`/api/admin/memories/${encodeURIComponent(id)}`,
+			{ method: "DELETE" },
+		);
+	},
+
+	restoreMemory(id: string) {
+		return request<{ id: string; restored: true }>(
+			`/api/admin/memories/${encodeURIComponent(id)}/restore`,
+			{ method: "POST" },
+		);
 	},
 
 	// --- Auth providers ---

--- a/server/ui/src/pages/memories.tsx
+++ b/server/ui/src/pages/memories.tsx
@@ -19,17 +19,28 @@ import {
 } from "@/components/ui/table";
 import { relativeTime } from "@/lib/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 const PAGE_SIZE = 20;
 const ALL = "__all__";
+
+const TYPE_COLORS: Record<string, string> = {
+	decision: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+	solution: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+	lesson: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+	fact: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+	convention: "bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-200",
+	goal: "bg-rose-100 text-rose-800 dark:bg-rose-900 dark:text-rose-200",
+};
 
 export function MemoriesPage() {
 	const queryClient = useQueryClient();
 	const [page, setPage] = useState(0);
 	const [selectedRemote, setSelectedRemote] = useState(ALL);
 	const [selectedScope, setSelectedScope] = useState(ALL);
+	const [selectedType, setSelectedType] = useState(ALL);
+	const [showDeleted, setShowDeleted] = useState(false);
 
 	const filtersQuery = useQuery({
 		queryKey: ["filters"],
@@ -37,11 +48,13 @@ export function MemoriesPage() {
 	});
 
 	const memoriesQuery = useQuery({
-		queryKey: ["memories", "list", selectedRemote, selectedScope, page],
+		queryKey: ["memories", "list", selectedRemote, selectedScope, selectedType, showDeleted, page],
 		queryFn: () =>
 			api.listMemories({
 				git_remote: selectedRemote !== ALL ? selectedRemote : undefined,
 				scope: selectedScope !== ALL ? selectedScope : undefined,
+				memory_type: selectedType !== ALL ? selectedType : undefined,
+				include_deleted: showDeleted || undefined,
 				limit: PAGE_SIZE,
 				offset: page * PAGE_SIZE,
 			}),
@@ -56,6 +69,14 @@ export function MemoriesPage() {
 		},
 	});
 
+	const restoreMutation = useMutation({
+		mutationFn: (id: string) => api.restoreMemory(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["memories"] });
+			queryClient.invalidateQueries({ queryKey: ["stats"] });
+		},
+	});
+
 	function handleRemoteChange(value: string) {
 		setSelectedRemote(value);
 		setPage(0);
@@ -66,18 +87,27 @@ export function MemoriesPage() {
 		setPage(0);
 	}
 
+	function handleTypeChange(value: string) {
+		setSelectedType(value);
+		setPage(0);
+	}
+
 	function clearFilters() {
 		setSelectedRemote(ALL);
 		setSelectedScope(ALL);
+		setSelectedType(ALL);
+		setShowDeleted(false);
 		setPage(0);
 	}
 
 	const projects = filtersQuery.data?.projects ?? [];
 	const scopes = filtersQuery.data?.scopes ?? [];
+	const types = filtersQuery.data?.types ?? [];
 	const memories = memoriesQuery.data?.memories ?? [];
 	const total = memoriesQuery.data?.total ?? 0;
 	const totalPages = Math.ceil(total / PAGE_SIZE);
-	const hasFilters = selectedRemote !== ALL || selectedScope !== ALL;
+	const hasFilters =
+		selectedRemote !== ALL || selectedScope !== ALL || selectedType !== ALL || showDeleted;
 
 	return (
 		<AppLayout>
@@ -120,6 +150,35 @@ export function MemoriesPage() {
 						</SelectContent>
 					</Select>
 				</div>
+				<div className="space-y-1">
+					<span id="type-filter-label" className="text-xs text-muted-foreground">
+						Type
+					</span>
+					<Select value={selectedType} onValueChange={handleTypeChange}>
+						<SelectTrigger className="w-40" aria-labelledby="type-filter-label">
+							<SelectValue placeholder="All types" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value={ALL}>All types</SelectItem>
+							{types.map((t) => (
+								<SelectItem key={t} value={t}>
+									{t}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+					<input
+						type="checkbox"
+						checked={showDeleted}
+						onChange={(e) => {
+							setShowDeleted(e.target.checked);
+							setPage(0);
+						}}
+					/>
+					Show deleted
+				</label>
 				{hasFilters && (
 					<Button size="sm" variant="ghost" onClick={clearFilters}>
 						Clear
@@ -143,7 +202,9 @@ export function MemoriesPage() {
 					<Table>
 						<TableHeader>
 							<TableRow>
-								<TableHead className="w-[40%]">Summary</TableHead>
+								<TableHead>Title</TableHead>
+								<TableHead className="w-[30%]">Summary</TableHead>
+								<TableHead>Type</TableHead>
 								<TableHead>Project</TableHead>
 								<TableHead>Scope</TableHead>
 								<TableHead>Created</TableHead>
@@ -151,31 +212,61 @@ export function MemoriesPage() {
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{memories.map((m) => (
-								<TableRow key={m.id}>
-									<TableCell className="font-medium">{m.summary}</TableCell>
-									<TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
-										{m.git_remote ?? "\u2014"}
-									</TableCell>
-									<TableCell>
-										<Badge variant="secondary">{m.scope}</Badge>
-									</TableCell>
-									<TableCell className="text-sm text-muted-foreground">
-										{relativeTime(m.created_at)}
-									</TableCell>
-									<TableCell>
-										<Button
-											size="icon"
-											variant="ghost"
-											aria-label="Delete memory"
-											disabled={deleteMutation.isPending}
-											onClick={() => deleteMutation.mutate(m.id)}
-										>
-											<Trash2 className="h-4 w-4" />
-										</Button>
-									</TableCell>
-								</TableRow>
-							))}
+							{memories.map((m) => {
+								const isDeleted = m.deleted_at != null;
+								return (
+									<TableRow key={m.id} className={isDeleted ? "opacity-50" : undefined}>
+										<TableCell className="max-w-[200px] truncate font-medium">
+											{m.title ?? "\u2014"}
+											{m.path && (
+												<span className="ml-1 text-xs text-muted-foreground">{m.path}</span>
+											)}
+										</TableCell>
+										<TableCell className="max-w-[300px] truncate text-sm text-muted-foreground">
+											{m.summary}
+										</TableCell>
+										<TableCell>
+											{m.memory_type && (
+												<Badge variant="secondary" className={TYPE_COLORS[m.memory_type] ?? ""}>
+													{m.memory_type}
+												</Badge>
+											)}
+										</TableCell>
+										<TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
+											{m.git_remote ?? "\u2014"}
+										</TableCell>
+										<TableCell>
+											<Badge variant="secondary">{m.scope}</Badge>
+										</TableCell>
+										<TableCell className="text-sm text-muted-foreground">
+											{relativeTime(m.created_at)}
+										</TableCell>
+										<TableCell>
+											{isDeleted ? (
+												<Button
+													size="icon"
+													variant="ghost"
+													aria-label="Restore memory"
+													disabled={restoreMutation.isPending}
+													onClick={() => restoreMutation.mutate(m.id)}
+												>
+													<RotateCcw className="h-4 w-4" />
+												</Button>
+											) : (
+												<Button
+													size="icon"
+													variant="ghost"
+													aria-label="Delete memory"
+													disabled={deleteMutation.isPending}
+													onClick={() => deleteMutation.mutate(m.id)}
+												>
+													<Trash2 className="h-4 w-4" />
+												</Button>
+											)}
+										</TableCell>
+									</TableRow>
+								);
+							})}
 						</TableBody>
 					</Table>
 


### PR DESCRIPTION
Closes #26

Evolve the memory model from flat text blobs into structured, navigable entities. When a memory is stored, an LLM call auto-generates a title, type, slug, and tree path — so memories become browseable and filterable without any extra effort from the caller.

## Changes

- **Schema** — 6 new nullable columns on `memories` (title, slug, memory_type, path, updated_at, deleted_at) with indexes and a unique slug constraint per scope+project
- **Classification** — Reuses the compression LLM provider (Anthropic/OpenRouter/Ollama) for a lightweight JSON classification call. Session-scoped memories skip LLM entirely. Falls back to deterministic defaults on any failure, so classification never blocks storage
- **Soft deletes** — `forget` now sets `deleted_at` instead of hard-deleting. New `restore` tool to undelete within a 30-day grace period. Retention sweep hard-purges after grace period
- **MCP tools** — `remember` gains title/type/path params, `search` gains type filter, `list_memories` gains type/path/include_deleted filters
- **Storage backends** — memory_type filter in both Qdrant and sqlite-vec
- **Admin UI** — Type and path filter dropdowns, colored type badges, soft-deleted rows shown at 50% opacity with restore button

Security: memory_type validated at HTTP boundary, include_deleted restricted to admins, NULL-safe slug uniqueness, empty slug fallback.

All 287 tests pass, lint clean, UI builds.